### PR TITLE
Add note to paxos lab that `Address[] servers` includes the current node

### DIFF
--- a/labs/lab3-paxos/src/dslabs/paxos/PaxosServer.java
+++ b/labs/lab3-paxos/src/dslabs/paxos/PaxosServer.java
@@ -11,6 +11,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class PaxosServer extends Node {
+    /** All servers in the paxos group, including ourselves (this node). */
     private final Address[] servers;
 
     // Your code here...


### PR DESCRIPTION
This was confusing to me and I had to print it out to check.