### PR TITLE
Path separation detection for native Windows build

### DIFF
--- a/handout-files/Makefile
+++ b/handout-files/Makefile
@@ -9,12 +9,17 @@ JC = javac -source 14 -g
 ################################################################################
 OUT = out
 
-SRC_JARS = jars/framework.jar:jars/framework-deps.jar
-TST_JARS = $(SRC_JARS):jars/grader.jar:jars/grader-deps.jar
+# Windows uses ; as a path separator while Linux and Mac use :
+SEP = ":"
+ifeq ($(OS),Windows_NT)
+	SEP=";"
+endif
+
+SRC_JARS = "jars/framework.jar"$(SEP)"jars/framework-deps.jar"
+TST_JARS = "$(SRC_JARS)$(SEP)"jars/grader.jar"$(SEP)"jars/grader-deps.jar""
 
 JAVA_SRC = $(shell find labs/*/src -type f -name "*.java")
 JAVA_TST = $(shell find labs/*/tst -type f -name "*.java")
-
 
 ################################################################################
 # Targets
@@ -34,7 +39,7 @@ $(OUT)/tst/: $(JAVA_TST) $(OUT)/src
 	@ echo "[javac] $@"
 	@ mkdir -p $@
 	@ touch $@
-	@ $(JC) -d $@ -cp $(TST_JARS):$(OUT)/src $(JAVA_TST)
+	@ $(JC) -d $@ -cp "$(TST_JARS)"$(SEP)"$(OUT)/src" $(JAVA_TST)
 
 
 submit.tar.gz:

--- a/handout-files/Makefile
+++ b/handout-files/Makefile
@@ -10,16 +10,17 @@ JC = javac -source 14 -g
 OUT = out
 
 # Windows uses ; as a path separator while Linux and Mac use :
-SEP = ":"
+SEP = :
 ifeq ($(OS),Windows_NT)
-	SEP=";"
+	SEP = ;
 endif
 
-SRC_JARS = "jars/framework.jar"$(SEP)"jars/framework-deps.jar"
-TST_JARS = "$(SRC_JARS)$(SEP)"jars/grader.jar"$(SEP)"jars/grader-deps.jar""
+SRC_JARS = jars/framework.jar$(SEP)jars/framework-deps.jar
+TST_JARS = $(SRC_JARS)$(SEP)jars/grader.jar$(SEP)jars/grader-deps.jar
 
 JAVA_SRC = $(shell find labs/*/src -type f -name "*.java")
 JAVA_TST = $(shell find labs/*/tst -type f -name "*.java")
+
 
 ################################################################################
 # Targets
@@ -33,13 +34,13 @@ $(OUT)/src/: $(JAVA_SRC)
 	@ echo "[javac] $@"
 	@ mkdir -p $@
 	@ touch $@
-	@ $(JC) -d $@ -cp $(SRC_JARS) $(JAVA_SRC)
+	@ $(JC) -d $@ -cp "$(SRC_JARS)" $(JAVA_SRC)
 
 $(OUT)/tst/: $(JAVA_TST) $(OUT)/src
 	@ echo "[javac] $@"
 	@ mkdir -p $@
 	@ touch $@
-	@ $(JC) -d $@ -cp "$(TST_JARS)"$(SEP)"$(OUT)/src" $(JAVA_TST)
+	@ $(JC) -d $@ -cp "$(TST_JARS)$(SEP)$(OUT)/src" $(JAVA_TST)
 
 
 submit.tar.gz:

--- a/handout-files/run-tests.py
+++ b/handout-files/run-tests.py
@@ -5,9 +5,9 @@
 
 import argparse
 import os
+import platform
 import shutil
 import subprocess
-import platform
 
 
 __author__ = 'Ellis Michael (emichael@cs.washington.edu)'
@@ -25,13 +25,14 @@ if platform.system() == 'Windows':
 else:
     CP_SEP = ':'
 
-CLASSPATHS = ['jars/framework.jar', 'jars/framework-deps.jar',
-              'jars/grader.jar', 'jars/grader-deps.jar', 'out/src/', 'out/tst/']
-
-RUNTIME_CLASSPATH = ""
-
-for P in CLASSPATHS:
-    RUNTIME_CLASSPATH += P + CP_SEP
+RUNTIME_CLASSPATH = CP_SEP.join((
+    'jars/framework.jar',
+    'jars/framework-deps.jar',
+    'jars/grader.jar',
+    'jars/grader-deps.jar',
+    'out/src/',
+    'out/tst/'
+))
 
 def make():
     """Compile the source files, return True if successful."""

--- a/handout-files/run-tests.py
+++ b/handout-files/run-tests.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import shutil
 import subprocess
+import platform
 
 
 __author__ = 'Ellis Michael (emichael@cs.washington.edu)'
@@ -19,14 +20,18 @@ SEARCH_CATEGORY = 'dslabs.framework.testing.junit.SearchTests'
 
 VIZ_DEBUGGER = 'dslabs.framework.testing.visualization.VizClient'
 
-RUNTIME_CLASSPATH = (
-    'jars/framework.jar:'
-    'jars/framework-deps.jar:'
-    'jars/grader.jar:'
-    'jars/grader-deps.jar:'
-    'out/src/:'
-    'out/tst/'
-)
+if platform.system() == 'Windows':
+    CP_SEP = ';'
+else:
+    CP_SEP = ':'
+
+CLASSPATHS = ['jars/framework.jar', 'jars/framework-deps.jar',
+              'jars/grader.jar', 'jars/grader-deps.jar', 'out/src/', 'out/tst/']
+
+RUNTIME_CLASSPATH = ""
+
+for P in CLASSPATHS:
+    RUNTIME_CLASSPATH += P + CP_SEP
 
 def make():
     """Compile the source files, return True if successful."""


### PR DESCRIPTION
This change detects the running platform and automatically chooses the correct path separator for Windows vs. Linux and Mac. I verified that it seems to work correctly on both Windows and Linux.

While this works on my system for building natively on Windows, my system has MinGW + MSYS installed and in the path. I'm unsure if it will work without that. 