### PR TITLE
Client specific workloads

### DIFF
--- a/framework/tst/dslabs/framework/testing/visualization/VizConfig.java
+++ b/framework/tst/dslabs/framework/testing/visualization/VizConfig.java
@@ -45,12 +45,26 @@ import java.util.List;
  */
 public abstract class VizConfig {
     public SearchState getInitialState(String[] args) {
-        return getInitialState(Integer.parseInt(args[0]),
-                Integer.parseInt(args[1]), commands(args[2]));
+        int numServers = Integer.parseInt(args[0]);
+        int numClients = Integer.parseInt(args[1]);
+        // The input is in one of the following formats:
+        //
+        // <# servers> <# clients> <uniform workload>
+        //
+        // <# servers> <# clients> <client 1 workload> ... <client n workload>
+        if (args.length != 3 && args.length != 2 + numClients) {
+            throw new IllegalArgumentException("Please provide either a single workload for all " +
+                                               "clients or a separate workload for each client.");
+        }
+        List<List<String>> commands = new LinkedList<>();
+        for (int i = 2; i < args.length; i++) {
+            commands.add(commands(args[i]));
+        }
+        return getInitialState(numServers, numClients, commands);
     }
 
     protected SearchState getInitialState(int numServers, int numClients,
-                                          List<String> commands) {
+                                          List<List<String>> commands) {
         List<Address> servers = new LinkedList<>();
         if (numServers == 1) {
             servers.add(new LocalAddress("server"));
@@ -84,11 +98,11 @@ public abstract class VizConfig {
 
     protected StateGenerator stateGenerator(List<Address> servers,
                                             List<Address> clients,
-                                            List<String> commands) {
+                                            List<List<String>> commands) {
         return stateGenerator(commands);
     }
 
-    protected StateGenerator stateGenerator(List<String> commands) {
+    protected StateGenerator stateGenerator(List<List<String>> commands) {
         return stateGenerator(Collections.emptyList(), Collections.emptyList(),
                 commands);
     }

--- a/framework/tst/dslabs/framework/testing/visualization/VizConfig.java
+++ b/framework/tst/dslabs/framework/testing/visualization/VizConfig.java
@@ -57,8 +57,17 @@ public abstract class VizConfig {
                                                "clients or a separate workload for each client.");
         }
         List<List<String>> commands = new LinkedList<>();
-        for (int i = 2; i < args.length; i++) {
-            commands.add(commands(args[i]));
+        if (args.length == 3) {
+            // Same workload for all clients
+            List<String> singleWorkload = commands(args[2]);
+            for (int i = 0; i < numClients; i++) {
+                commands.add(singleWorkload);
+            }
+        } else {
+            // Specific workload for each client
+            for (int i = 0; i < numClients; i++) {
+                commands.add(commands(args[2 + i]));
+            }
         }
         return getInitialState(numServers, numClients, commands);
     }

--- a/handout-files/README.md
+++ b/handout-files/README.md
@@ -267,17 +267,17 @@ Included in this handout is a tool for visualizing and graphically debugging
 executions of distributed systems. You can run it in two different ways. First,
 you can start any lab from its initial state by calling `./run-tests.py --lab N
 --debug NUM_SERVERS NUM_CLIENTS WORKLOAD` or `./run-tests.py --lab N --debug
-NUM_SERVERS NUM_CLIENTS WORKLOAD_1 ... WORKLOAD_N`. Here `WORKLOAD`/`WORKLOAD_i`
-is a comma-separated list of commands for the clients to send (e.g.,
-`PUT:foo:bar,APPEND:foo:baz,GET:foo`). If only one workload is provided, all
-clients will send the same workload; if `NUM_CLIENTS` workloads are provided,
-then client `i` will send `WORKLOAD_i`. You can even write custom parsers for
-the arguments to `--debug` by overriding `getInitialState(String[] args)` in the
-relevant subclass of `VizConfig`. The visualization tool will startup Google
-Chrome, which is the only supported browser at this time. If it cannot open a
-Chrome window, you should open a Chrome tab manually and navigate to
-`localhost:3000`. Once your list of servers appears in the top-right, click on
-"Debug!".
+NUM_SERVERS NUM_CLIENTS WORKLOAD_1 ... WORKLOAD_NUM_CLIENTS`. Here
+`WORKLOAD`/`WORKLOAD_i` is a comma-separated list of commands for the clients to
+send (e.g., `PUT:foo:bar,APPEND:foo:baz,GET:foo`). If only one workload is
+provided, all clients will send the same workload; if `NUM_CLIENTS` workloads
+are provided, then client `i` will send `WORKLOAD_i`. You can even write custom
+parsers for the arguments to `--debug` by overriding `getInitialState(String[]
+args)` in the relevant subclass of `VizConfig`. The visualization tool will
+startup Google Chrome, which is the only supported browser at this time. If it
+cannot open a Chrome window, you should open a Chrome tab manually and navigate
+to `localhost:3000`. Once your list of servers appears in the top-right, click
+on "Debug!".
 
 ![Debug Startup](img/debug-startup.png)
 

--- a/handout-files/README.md
+++ b/handout-files/README.md
@@ -271,8 +271,8 @@ NUM_SERVERS NUM_CLIENTS WORKLOAD_1 ... WORKLOAD_N`. Here `WORKLOAD`/`WORKLOAD_i`
 is a comma-separated list of commands for the clients to send (e.g.,
 `PUT:foo:bar,APPEND:foo:baz,GET:foo`). If only one workload is provided, all
 clients will send the same workload; if `NUM_CLIENTS` workloads are provided,
-then client i will send `WORKLOAD_i`. You can even write custom parsers for the
-arguments to `--debug` by overriding `getInitialState(String[] args)` in the
+then client `i` will send `WORKLOAD_i`. You can even write custom parsers for
+the arguments to `--debug` by overriding `getInitialState(String[] args)` in the
 relevant subclass of `VizConfig`. The visualization tool will startup Google
 Chrome, which is the only supported browser at this time. If it cannot open a
 Chrome window, you should open a Chrome tab manually and navigate to

--- a/handout-files/README.md
+++ b/handout-files/README.md
@@ -266,9 +266,12 @@ overriding those methods (and calling the `super` method of course).
 Included in this handout is a tool for visualizing and graphically debugging
 executions of distributed systems. You can run it in two different ways. First,
 you can start any lab from its initial state by calling `./run-tests.py --lab N
---debug NUM_SERVERS NUM_CLIENTS WORKLOAD`, where `WORKLOAD` is a comma-separated
-list of commands for the clients to send (e.g.,
-`PUT:foo:bar,APPEND:foo:baz,GET:foo`). You can even write custom parsers for the
+--debug NUM_SERVERS NUM_CLIENTS WORKLOAD` or `./run-tests.py --lab N --debug
+NUM_SERVERS NUM_CLIENTS WORKLOAD_1 ... WORKLOAD_N`. Here `WORKLOAD`/`WORKLOAD_i`
+is a comma-separated list of commands for the clients to send (e.g.,
+`PUT:foo:bar,APPEND:foo:baz,GET:foo`). If only one workload is provided, all
+clients will send the same workload; if `NUM_CLIENTS` workloads are provided,
+then client i will send `WORKLOAD_i`. You can even write custom parsers for the
 arguments to `--debug` by overriding `getInitialState(String[] args)` in the
 relevant subclass of `VizConfig`. The visualization tool will startup Google
 Chrome, which is the only supported browser at this time. If it cannot open a

--- a/handout-files/run-tests.py
+++ b/handout-files/run-tests.py
@@ -178,7 +178,13 @@ def main():
                         "should be: NUM_SERVERS NUM_CLIENTS WORKLOAD where "
                         "WORKLOAD is a comma-separated list of commands (e.g., "
                         "PUT:foo:bar,APPEND:foo:baz,GET:foo in the default "
-                        "case of the KVStore).")
+                        "case of the KVStore); with these arguments, all "
+                        "clients request the same workload. To give different "
+                        "workloads for each client, the args should be: "
+                        "NUM_SERVERS NUM_CLIENTS WORKLOAD_1 WORKLOAD_2 ... "
+                        "WORKLOAD_N where each WORLOAD_j is a comma-separated "
+                        "list of commands and a workload is provided for each "
+                        "client.")
 
     parser.add_argument('--no-viz-server', action='store_true',
                         help="do not automatically start the visualization "

--- a/handout-files/run-tests.py
+++ b/handout-files/run-tests.py
@@ -182,9 +182,9 @@ def main():
                         "clients request the same workload. To give different "
                         "workloads for each client, the args should be: "
                         "NUM_SERVERS NUM_CLIENTS WORKLOAD_1 WORKLOAD_2 ... "
-                        "WORKLOAD_N where each WORLOAD_j is a comma-separated "
-                        "list of commands and a workload is provided for each "
-                        "client.")
+                        "WORKLOAD_NUM_CLIENTS where each WORLOAD_i is a "
+                        "comma-separated list of commands and a workload is "
+                        "provided for each client.")
 
     parser.add_argument('--no-viz-server', action='store_true',
                         help="do not automatically start the visualization "

--- a/labs/lab0-pingpong/tst/dslabs/pingpong/PingVizConfig.java
+++ b/labs/lab0-pingpong/tst/dslabs/pingpong/PingVizConfig.java
@@ -1,5 +1,6 @@
 package dslabs.pingpong;
 
+import dslabs.framework.Address;
 import dslabs.framework.testing.StateGenerator;
 import dslabs.framework.testing.StateGenerator.StateGeneratorBuilder;
 import dslabs.framework.testing.Workload;
@@ -15,7 +16,7 @@ import static dslabs.pingpong.PingTest.sa;
 public class PingVizConfig extends VizConfig {
     @Override
     public SearchState getInitialState(int numServers, int numClients,
-                                       List<String> commands) {
+                                       List<List<String>> commands) {
         SearchState searchState =
                 super.getInitialState(0, numClients, commands);
         searchState.addServer(sa);
@@ -23,10 +24,17 @@ public class PingVizConfig extends VizConfig {
     }
 
     @Override
-    protected StateGenerator stateGenerator(List<String> workload) {
+    protected StateGenerator stateGenerator(List<Address> servers,
+                                            List<Address> clients,
+                                            List<List<String>> workload) {
         StateGeneratorBuilder builder = builder();
-        builder.workloadSupplier(__ -> Workload.workload(
-                workload.stream().map(Ping::new).collect(Collectors.toList())));
+        if (workload.size() == 1) {
+            builder.workloadSupplier(__ -> Workload.workload(
+                workload.get(0).stream().map(Ping::new).collect(Collectors.toList())));
+        } else {
+            builder.workloadSupplier(a -> Workload.workload(
+                workload.get(clients.indexOf(a)).stream().map(Ping::new).collect(Collectors.toList())));
+        }
         return builder.build();
     }
 }

--- a/labs/lab0-pingpong/tst/dslabs/pingpong/PingVizConfig.java
+++ b/labs/lab0-pingpong/tst/dslabs/pingpong/PingVizConfig.java
@@ -28,13 +28,8 @@ public class PingVizConfig extends VizConfig {
                                             List<Address> clients,
                                             List<List<String>> workload) {
         StateGeneratorBuilder builder = builder();
-        if (workload.size() == 1) {
-            builder.workloadSupplier(__ -> Workload.workload(
-                workload.get(0).stream().map(Ping::new).collect(Collectors.toList())));
-        } else {
-            builder.workloadSupplier(a -> Workload.workload(
-                workload.get(clients.indexOf(a)).stream().map(Ping::new).collect(Collectors.toList())));
-        }
+        builder.workloadSupplier(a -> Workload.workload(
+            workload.get(clients.indexOf(a)).stream().map(Ping::new).collect(Collectors.toList())));
         return builder.build();
     }
 }

--- a/labs/lab1-clientserver/tst/dslabs/clientserver/CSVizConfig.java
+++ b/labs/lab1-clientserver/tst/dslabs/clientserver/CSVizConfig.java
@@ -1,5 +1,6 @@
 package dslabs.clientserver;
 
+import dslabs.framework.Address;
 import dslabs.framework.testing.StateGenerator;
 import dslabs.framework.testing.StateGenerator.StateGeneratorBuilder;
 import dslabs.framework.testing.search.SearchState;
@@ -13,7 +14,7 @@ import static dslabs.clientserver.ClientServerBaseTest.builder;
 public class CSVizConfig extends VizConfig {
     @Override
     public SearchState getInitialState(int numServers, int numClients,
-                                       List<String> commands) {
+                                       List<List<String>> commands) {
         SearchState searchState =
                 super.getInitialState(0, numClients, commands);
         searchState.addServer(SA);
@@ -21,11 +22,17 @@ public class CSVizConfig extends VizConfig {
     }
 
     @Override
-    protected StateGenerator stateGenerator(List<String> workload) {
+    protected StateGenerator stateGenerator(List<Address> servers,
+                                            List<Address> clients,
+                                            List<List<String>> workload) {
         StateGeneratorBuilder builder = builder();
-        builder.workloadSupplier(
-                KVStoreWorkload.builder().commandStrings(workload).build());
+        if (workload.size() == 1) {
+            builder.workloadSupplier(__ ->
+                KVStoreWorkload.builder().commandStrings(workload.get(0)).build());
+        } else {
+            builder.workloadSupplier(a ->
+                KVStoreWorkload.builder().commandStrings(workload.get(clients.indexOf(a))).build());
+        }
         return builder.build();
     }
 }
-

--- a/labs/lab1-clientserver/tst/dslabs/clientserver/CSVizConfig.java
+++ b/labs/lab1-clientserver/tst/dslabs/clientserver/CSVizConfig.java
@@ -26,13 +26,8 @@ public class CSVizConfig extends VizConfig {
                                             List<Address> clients,
                                             List<List<String>> workload) {
         StateGeneratorBuilder builder = builder();
-        if (workload.size() == 1) {
-            builder.workloadSupplier(__ ->
-                KVStoreWorkload.builder().commandStrings(workload.get(0)).build());
-        } else {
-            builder.workloadSupplier(a ->
-                KVStoreWorkload.builder().commandStrings(workload.get(clients.indexOf(a))).build());
-        }
+        builder.workloadSupplier(a ->
+            KVStoreWorkload.builder().commandStrings(workload.get(clients.indexOf(a))).build());
         return builder.build();
     }
 }

--- a/labs/lab2-primarybackup/tst/dslabs/primarybackup/PBVizConfig.java
+++ b/labs/lab2-primarybackup/tst/dslabs/primarybackup/PBVizConfig.java
@@ -1,5 +1,6 @@
 package dslabs.primarybackup;
 
+import dslabs.framework.Address;
 import dslabs.framework.testing.StateGenerator;
 import dslabs.framework.testing.StateGenerator.StateGeneratorBuilder;
 import dslabs.framework.testing.search.SearchState;
@@ -13,7 +14,7 @@ import static dslabs.primarybackup.ViewServerTest.VSA;
 public class PBVizConfig extends VizConfig {
     @Override
     public SearchState getInitialState(int numServers, int numClients,
-                                       List<String> commands) {
+                                       List<List<String>> commands) {
         SearchState searchState =
                 super.getInitialState(numServers, numClients, commands);
         searchState.addServer(VSA);
@@ -21,11 +22,17 @@ public class PBVizConfig extends VizConfig {
     }
 
     @Override
-    protected StateGenerator stateGenerator(List<String> commands) {
+    protected StateGenerator stateGenerator(List<Address> servers,
+                                            List<Address> clients,
+                                            List<List<String>> workload) {
         StateGeneratorBuilder builder = builder();
-        builder.workloadSupplier(
-                KVStoreWorkload.builder().commandStrings(commands).build());
+        if (workload.size() == 1) {
+            builder.workloadSupplier(__ ->
+                KVStoreWorkload.builder().commandStrings(workload.get(0)).build());
+        } else {
+            builder.workloadSupplier(a ->
+                KVStoreWorkload.builder().commandStrings(workload.get(clients.indexOf(a))).build());
+        }
         return builder.build();
     }
 }
-

--- a/labs/lab2-primarybackup/tst/dslabs/primarybackup/PBVizConfig.java
+++ b/labs/lab2-primarybackup/tst/dslabs/primarybackup/PBVizConfig.java
@@ -26,13 +26,8 @@ public class PBVizConfig extends VizConfig {
                                             List<Address> clients,
                                             List<List<String>> workload) {
         StateGeneratorBuilder builder = builder();
-        if (workload.size() == 1) {
-            builder.workloadSupplier(__ ->
-                KVStoreWorkload.builder().commandStrings(workload.get(0)).build());
-        } else {
-            builder.workloadSupplier(a ->
-                KVStoreWorkload.builder().commandStrings(workload.get(clients.indexOf(a))).build());
-        }
+        builder.workloadSupplier(a ->
+            KVStoreWorkload.builder().commandStrings(workload.get(clients.indexOf(a))).build());
         return builder.build();
     }
 }

--- a/labs/lab3-paxos/tst/dslabs/paxos/PaxosVizConfig.java
+++ b/labs/lab3-paxos/tst/dslabs/paxos/PaxosVizConfig.java
@@ -13,11 +13,16 @@ public class PaxosVizConfig extends VizConfig {
     @Override
     protected StateGenerator stateGenerator(List<Address> servers,
                                             List<Address> clients,
-                                            List<String> commands) {
+                                            List<List<String>> workload) {
         final Address[] serverAddresses = servers.toArray(new Address[0]);
         StateGeneratorBuilder builder = builder(serverAddresses);
-        builder.workloadSupplier(
-                KVStoreWorkload.builder().commandStrings(commands).build());
+        if (workload.size() == 1) {
+            builder.workloadSupplier(__ ->
+                KVStoreWorkload.builder().commandStrings(workload.get(0)).build());
+        } else {
+            builder.workloadSupplier(a ->
+                KVStoreWorkload.builder().commandStrings(workload.get(clients.indexOf(a))).build());
+        }
         return builder.build();
     }
 }

--- a/labs/lab3-paxos/tst/dslabs/paxos/PaxosVizConfig.java
+++ b/labs/lab3-paxos/tst/dslabs/paxos/PaxosVizConfig.java
@@ -16,13 +16,8 @@ public class PaxosVizConfig extends VizConfig {
                                             List<List<String>> workload) {
         final Address[] serverAddresses = servers.toArray(new Address[0]);
         StateGeneratorBuilder builder = builder(serverAddresses);
-        if (workload.size() == 1) {
-            builder.workloadSupplier(__ ->
-                KVStoreWorkload.builder().commandStrings(workload.get(0)).build());
-        } else {
-            builder.workloadSupplier(a ->
-                KVStoreWorkload.builder().commandStrings(workload.get(clients.indexOf(a))).build());
-        }
+        builder.workloadSupplier(a ->
+            KVStoreWorkload.builder().commandStrings(workload.get(clients.indexOf(a))).build());
         return builder.build();
     }
 }

--- a/labs/lab4-shardedstore/README.md
+++ b/labs/lab4-shardedstore/README.md
@@ -325,8 +325,8 @@ You should pass the part 3 tests; execute them with `run-tests.py --lab 4 --part
 The arguments to start the visual debugger for this lab are slightly different.
 To start the visual debugger, execute `./run-tests.py -d NUM_GROUPS
 NUM_SERVERS_PER_GROUP NUM_SHARDMASTERS NUM_CLIENTS CLIENT_WORKLOAD
-[config=CONFIG_WORKLOAD]` or `./run-tests.py -d NUM_GROUPS NUM_SERVERS_PER_GROUP
-NUM_SHARDMASTERS NUM_CLIENTS CLIENT_WORKLOAD_1 ... CLIENT_WORKLOAD_N
+[CONFIG_WORKLOAD]` or `./run-tests.py -d NUM_GROUPS NUM_SERVERS_PER_GROUP
+NUM_SHARDMASTERS NUM_CLIENTS CLIENT_WORKLOAD_1 ... CLIENT_WORKLOAD_NUM_CLIENTS
 [config=CONFIG_WORKLOAD]` where:
 - `NUM_GROUPS` is the number of `ShardStoreServer` groups
 - `NUM_SERVERS_PER_GROUP` is the number of `ShardStoreServer`s in each group

--- a/labs/lab4-shardedstore/README.md
+++ b/labs/lab4-shardedstore/README.md
@@ -325,15 +325,20 @@ You should pass the part 3 tests; execute them with `run-tests.py --lab 4 --part
 The arguments to start the visual debugger for this lab are slightly different.
 To start the visual debugger, execute `./run-tests.py -d NUM_GROUPS
 NUM_SERVERS_PER_GROUP NUM_SHARDMASTERS NUM_CLIENTS CLIENT_WORKLOAD
-[CONFIG_WORKLOAD]` where:
+[config=CONFIG_WORKLOAD]` or `./run-tests.py -d NUM_GROUPS NUM_SERVERS_PER_GROUP
+NUM_SHARDMASTERS NUM_CLIENTS CLIENT_WORKLOAD_1 ... CLIENT_WORKLOAD_N
+[config=CONFIG_WORKLOAD]` where:
 - `NUM_GROUPS` is the number of `ShardStoreServer` groups
 - `NUM_SERVERS_PER_GROUP` is the number of `ShardStoreServer`s in each group
 - `NUM_SHARDMASTERS` is the number of Paxos servers replicating the
   `ShardMaster`
 - `NUM_CLIENTS` is the number of `ShardStoreClient`s
-- `CLIENT_WORKLOAD` is the `ShardStoreClient`'s workload, a comma-separated list
-  of `KVStoreCommand`s. These can include `GET`, `PUT`, and `APPEND`, which have
-  the normal syntax, as well as transactions, which have the following syntax:
+- `CLIENT_WORKLOAD`/`CLIENT_WORKLOAD_i` is a `ShardStoreClient`'s workload, a
+  comma-separated list of `KVStoreCommand`s. As before, if a single workload is
+  provided then all clients will send that workload, and if `NUM_CLIENTS`
+  workloads are provided then client i will send `CLIENT_WORKLOAD_i`. Workloads
+  can include `GET`, `PUT`, and `APPEND`, which have the normal syntax, as well
+  as transactions, which have the following syntax:
   - `MULTIGET:key1:key2:...:keyN`
   - `MULTIPUT:key1:value1:key2:value2:...:keyN:valueN`
   - `SWAP:key1:key2`

--- a/labs/lab4-shardedstore/README.md
+++ b/labs/lab4-shardedstore/README.md
@@ -336,9 +336,10 @@ NUM_SHARDMASTERS NUM_CLIENTS CLIENT_WORKLOAD_1 ... CLIENT_WORKLOAD_N
 - `CLIENT_WORKLOAD`/`CLIENT_WORKLOAD_i` is a `ShardStoreClient`'s workload, a
   comma-separated list of `KVStoreCommand`s. As before, if a single workload is
   provided then all clients will send that workload, and if `NUM_CLIENTS`
-  workloads are provided then client i will send `CLIENT_WORKLOAD_i`. Workloads
-  can include `GET`, `PUT`, and `APPEND`, which have the normal syntax, as well
-  as transactions, which have the following syntax:
+  workloads are provided then client `i` will send
+  `CLIENT_WORKLOAD_i`. Workloads can include `GET`, `PUT`, and `APPEND`, which
+  have the normal syntax, as well as transactions, which have the following
+  syntax:
   - `MULTIGET:key1:key2:...:keyN`
   - `MULTIPUT:key1:value1:key2:value2:...:keyN:valueN`
   - `SWAP:key1:key2`

--- a/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStoreVizConfig.java
+++ b/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStoreVizConfig.java
@@ -39,6 +39,15 @@ public class ShardStoreVizConfig extends VizConfig {
         }
     }
 
+    private List<String> getConfigCommandsIfPresent(String[] args) {
+        if (args[args.length - 1].startsWith("JOIN") ||
+            args[args.length - 1].startsWith("LEAVE") ||
+            args[args.length - 1].startsWith("MOVE")) {
+            return commands(args[args.length - 1]);
+        }
+        return null;
+    }
+
     @Override
     public SearchState getInitialState(String[] args) {
         int numGroups = Integer.parseInt(args[0]);
@@ -47,9 +56,8 @@ public class ShardStoreVizConfig extends VizConfig {
         int numClients = Integer.parseInt(args[3]);
         int commandStart = 4;
         int commandEnd = args.length;
-        List<String> configCommands = null;
-        if (args[args.length - 1].startsWith("config=")) {
-            configCommands = commands(args[args.length - 1].substring("config=".length()));
+        List<String> configCommands = getConfigCommandsIfPresent(args);
+        if (configCommands != null) {
             commandEnd--;
         }
         if (commandEnd - commandStart != 1 && commandEnd - commandStart != numClients) {


### PR DESCRIPTION
# Allow client-specific workloads in the visual debugger

Some tests in the test suite use "non-uniform" workloads, where different clients send different sequences of commands. (For example, this is common with append commands to test linearizability.) In dslabs master, the visual debugger is not easy to use on such workloads, because the command-line interface assumes/requires *uniform* client workloads, where each client sends the same sequence of commands.

This PR adds support to the CLI for non-uniform client workloads. Lab 4 is especially tricky, due to reconfiguration commands being mixed in as well.

This is a draft implemented by my TA Logan Gnanapragasam. (Not sure his github id.) We have deployed this draft to this quarter's students and may incorporate their feedback here as well.

Commit messages pasted/lightly edited below.

## Labs 0 - 3

The input
after -d should be in one of the following forms:
- "<# servers> <# clients> <single workload>"
- "<# servers> <# clients> <client1 workload> ... <clientn workload>"
where each workload is a comma-separated list of commands.

Tests: manually ran the visual debugger with the updated code in my
solution repository.
- Checked that a single workload can be given to all clients
- Checked that distinct workloads can be given to each client
- Checked for an error if user provides incorrect # of workloads

## Lab 4

The tricky part is that since we also allow a custom configuration
workload, we can't simply say that the format is

`<# groups> <# servers/group> <# shardmasters> <# clients>
    <client 1 workload> (... <client n workload>) <config workload>`.

Consider the following two inputs.

- 1 1 1 2 "APPEND:foo:bar" "JOIN:1"
- 1 1 1 2 "APPEND:foo:bar" "APPEND:foo:baz"

Both have the same number of args; without trying to parse the string
into a command, it's hard to determine that the first case is a custom
config workload with a uniform client workload, while the second case
is the default config workload with specific workloads per client.

To distinguish between these, this change requests that the config workload
should be prefixed with "config=", e.g.:

- 1 1 1 2 "APPEND:foo:bar" config="JOIN:1"

Manually tested: ran lab 4 visual debugger and confirmed that (a) we
can specify new configs and (b) we can specify custom workloads for
nodes.  Specifically, ran the following four commands:
./run-tests.py -l 4 -d 2 1 1 2 "APPEND:foo:bar"
./run-tests.py -l 4 -d 2 1 1 2 "APPEND:foo:bar" config="JOIN:1,JOIN:2,MOVE:1:4"
./run-tests.py -l 4 -d 2 1 1 2 "APPEND:foo:bar" "APPEND:foo:baz"
./run-tests.py -l 4 -d 2 1 1 2 "APPEND:foo:bar" "APPEND:foo:baz" config="JOIN:1,JOIN:2,MOVE:1:4"