### PR TITLE
Open visual debugger when goal not found

### DIFF
--- a/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
+++ b/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
@@ -358,11 +358,6 @@ public abstract class BaseJUnitTest {
         return searchResults.goalMatchingState();
     }
 
-    protected final void assertGoalFound() {
-        assert !searchResults.goalsSought().isEmpty();
-        assertGoalFound(null, false);
-    }
-
     protected final void assertGoalReachableFrom(SearchState start) {
         bfs(start);
         assertGoalFound(start, false);

--- a/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
+++ b/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
@@ -348,7 +348,12 @@ public abstract class BaseJUnitTest {
     }
 
     protected final SearchState findGoalMatchingStateFrom(SearchState start) {
-        bfs(start);
+        return findGoalMatchingStateFrom(start, searchSettings);
+    }
+
+    protected final SearchState findGoalMatchingStateFrom(SearchState start,
+                                                          SearchSettings settings) {
+        bfs(start, settings);
         assertGoalFound(start, true);
         return searchResults.goalMatchingState();
     }

--- a/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
+++ b/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
@@ -347,8 +347,19 @@ public abstract class BaseJUnitTest {
         return searchResults.goalMatchingState();
     }
 
-    protected final void assertGoalFound(SearchState start) {
+    protected final SearchState findGoalMatchingStateFrom(SearchState start) {
+        bfs(start);
+        assertGoalFound(start, true);
+        return searchResults.goalMatchingState();
+    }
+
+    protected final void assertGoalFound() {
         assert !searchResults.goalsSought().isEmpty();
+        assertGoalFound(null, false);
+    }
+
+    protected final void assertGoalReachableFrom(SearchState start) {
+        bfs(start);
         assertGoalFound(start, false);
     }
 

--- a/labs/lab0-pingpong/tst/dslabs/pingpong/PingTest.java
+++ b/labs/lab0-pingpong/tst/dslabs/pingpong/PingTest.java
@@ -126,7 +126,7 @@ public final class PingTest extends BaseJUnitTest {
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(10);
         bfs(initSearchState);
-        assertGoalFound();
+        assertGoalFound(initSearchState);
 
         System.out
                 .println("Checking that all of the returned pongs match pings");

--- a/labs/lab0-pingpong/tst/dslabs/pingpong/PingTest.java
+++ b/labs/lab0-pingpong/tst/dslabs/pingpong/PingTest.java
@@ -125,8 +125,7 @@ public final class PingTest extends BaseJUnitTest {
         System.out.println("Checking that the client can finish all pings");
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(10);
-        bfs(initSearchState);
-        assertGoalFound(initSearchState);
+        assertGoalReachableFrom(initSearchState);
 
         System.out
                 .println("Checking that all of the returned pongs match pings");

--- a/labs/lab1-clientserver/tst/dslabs/clientserver/ClientServerPart2Test.java
+++ b/labs/lab1-clientserver/tst/dslabs/clientserver/ClientServerPart2Test.java
@@ -193,8 +193,7 @@ public final class ClientServerPart2Test extends ClientServerBaseTest {
         System.out.println("Checking that an end state is reachable");
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(10);
-        bfs(initSearchState);
-        assertGoalFound(initSearchState);
+        assertGoalReachableFrom(initSearchState);
 
         System.out.println("Checking that all reachable states are good");
         searchSettings.clearGoals().addPrune(CLIENTS_DONE);
@@ -220,8 +219,7 @@ public final class ClientServerPart2Test extends ClientServerBaseTest {
         System.out.println("Checking that an end state is reachable");
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(10);
-        bfs(initSearchState);
-        assertGoalFound(initSearchState);
+        assertGoalReachableFrom(initSearchState);
 
         System.out.println("Checking that all reachable states are good");
         searchSettings.clearGoals().addPrune(CLIENTS_DONE);
@@ -244,8 +242,7 @@ public final class ClientServerPart2Test extends ClientServerBaseTest {
         System.out.println("Checking that an end state is reachable");
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(30);
-        bfs(initSearchState);
-        assertGoalFound(initSearchState);
+        assertGoalReachableFrom(initSearchState);
 
         System.out.println("Checking that all reachable states are good");
         searchSettings.clearGoals().addPrune(CLIENTS_DONE);
@@ -270,8 +267,7 @@ public final class ClientServerPart2Test extends ClientServerBaseTest {
         System.out.println("Checking that an end state is reachable");
         searchSettings.addInvariant(APPENDS_LINEARIZABLE).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(30);
-        bfs(initSearchState);
-        assertGoalFound(initSearchState);
+        assertGoalReachableFrom(initSearchState);
 
         System.out.println("Checking that all reachable states are good");
         searchSettings.clearGoals().addPrune(CLIENTS_DONE);

--- a/labs/lab1-clientserver/tst/dslabs/clientserver/ClientServerPart2Test.java
+++ b/labs/lab1-clientserver/tst/dslabs/clientserver/ClientServerPart2Test.java
@@ -194,7 +194,7 @@ public final class ClientServerPart2Test extends ClientServerBaseTest {
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(10);
         bfs(initSearchState);
-        assertGoalFound();
+        assertGoalFound(initSearchState);
 
         System.out.println("Checking that all reachable states are good");
         searchSettings.clearGoals().addPrune(CLIENTS_DONE);
@@ -221,7 +221,7 @@ public final class ClientServerPart2Test extends ClientServerBaseTest {
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(10);
         bfs(initSearchState);
-        assertGoalFound();
+        assertGoalFound(initSearchState);
 
         System.out.println("Checking that all reachable states are good");
         searchSettings.clearGoals().addPrune(CLIENTS_DONE);
@@ -245,7 +245,7 @@ public final class ClientServerPart2Test extends ClientServerBaseTest {
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(30);
         bfs(initSearchState);
-        assertGoalFound();
+        assertGoalFound(initSearchState);
 
         System.out.println("Checking that all reachable states are good");
         searchSettings.clearGoals().addPrune(CLIENTS_DONE);
@@ -271,7 +271,7 @@ public final class ClientServerPart2Test extends ClientServerBaseTest {
         searchSettings.addInvariant(APPENDS_LINEARIZABLE).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(30);
         bfs(initSearchState);
-        assertGoalFound();
+        assertGoalFound(initSearchState);
 
         System.out.println("Checking that all reachable states are good");
         searchSettings.clearGoals().addPrune(CLIENTS_DONE);

--- a/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java
+++ b/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java
@@ -169,8 +169,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
                 .linkActive(backup, primary, true);
         }
 
-        bfs(startState, temp);
-        SearchState current = goalMatchingState();
+        SearchState current = findGoalMatchingStateFrom(startState, temp);
         clearSearchResults();
 
         // Deliver each of the view replies in turn
@@ -753,8 +752,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
                                     .map(MessageEnvelope::from)
                                     .collect(Collectors.toSet())
                                     .containsAll(senders)));
-        bfs(viewInitialized);
-        final SearchState requestsSent = goalMatchingState();
+        final SearchState requestsSent = findGoalMatchingStateFrom(viewInitialized);
         System.out.println("Client requests sent.\n");
 
         // Grab the messages sent by the clients
@@ -856,8 +854,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
         searchSettings.maxTimeSecs(10).partition(server(1), client(1), VSA)
                       .addInvariant(RESULTS_OK).addGoal(clientDone(client(1)))
                       .addPrune(hasViewReply(INITIAL_VIEWNUM + 3));
-        bfs(primaryAlone);
-        final SearchState client1Done = goalMatchingState();
+        final SearchState client1Done = findGoalMatchingStateFrom(primaryAlone);
 
         // Make sure that the second client can finish, sending message to backup
         searchSettings.maxTimeSecs(30).resetNetwork()

--- a/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java
+++ b/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java
@@ -686,7 +686,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(30);
         bfs(initSearchState);
-        assertGoalFound();
+        assertGoalFound(initSearchState);
 
         // Make sure results match
         searchSettings.clearGoals().addPrune(CLIENTS_DONE).maxTimeSecs(30);
@@ -711,7 +711,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
                       .addPrune(hasViewReply(INITIAL_VIEWNUM + 2))
                       .maxTimeSecs(20).nodeActive(server(3), false);
         bfs(viewInitializedState);
-        assertGoalFound();
+        assertGoalFound(viewInitializedState);
 
         // Make sure results match
         searchSettings.clearGoals().clearPrunes().addPrune(CLIENTS_DONE)
@@ -805,7 +805,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
         searchSettings.clear().addInvariant(APPENDS_LINEARIZABLE)
                       .addGoal(CLIENTS_DONE).maxTimeSecs(20);
         bfs(forwardedReversed);
-        assertGoalFound();
+        assertGoalFound(forwardedReversed);
 
         // Make sure linearizability is preserved
         searchSettings.clearGoals().addPrune(CLIENTS_DONE)
@@ -876,7 +876,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
                                                  .negate())
                       .addPrune(hasViewReply(INITIAL_VIEWNUM + 5));
         bfs(client1Done);
-        assertGoalFound();
+        assertGoalFound(client1Done);
 
         searchSettings.clearGoals();
         bfs(client1Done);

--- a/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java
+++ b/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java
@@ -685,8 +685,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
         // Make sure clients can finish
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(30);
-        bfs(initSearchState);
-        assertGoalFound(initSearchState);
+        assertGoalReachableFrom(initSearchState);
 
         // Make sure results match
         searchSettings.clearGoals().addPrune(CLIENTS_DONE).maxTimeSecs(30);
@@ -710,8 +709,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
         searchSettings.addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .addPrune(hasViewReply(INITIAL_VIEWNUM + 2))
                       .maxTimeSecs(20).nodeActive(server(3), false);
-        bfs(viewInitializedState);
-        assertGoalFound(viewInitializedState);
+        assertGoalReachableFrom(viewInitializedState);
 
         // Make sure results match
         searchSettings.clearGoals().clearPrunes().addPrune(CLIENTS_DONE)
@@ -804,8 +802,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
         // Make sure clients can finish from here
         searchSettings.clear().addInvariant(APPENDS_LINEARIZABLE)
                       .addGoal(CLIENTS_DONE).maxTimeSecs(20);
-        bfs(forwardedReversed);
-        assertGoalFound(forwardedReversed);
+        assertGoalReachableFrom(forwardedReversed);
 
         // Make sure linearizability is preserved
         searchSettings.clearGoals().addPrune(CLIENTS_DONE)
@@ -875,8 +872,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
                         hasViewReply(INITIAL_VIEWNUM + 4, server(2), null))
                                                  .negate())
                       .addPrune(hasViewReply(INITIAL_VIEWNUM + 5));
-        bfs(client1Done);
-        assertGoalFound(client1Done);
+        assertGoalReachableFrom(client1Done);
 
         searchSettings.clearGoals();
         bfs(client1Done);

--- a/labs/lab3-paxos/tst/dslabs/paxos/PaxosTest.java
+++ b/labs/lab3-paxos/tst/dslabs/paxos/PaxosTest.java
@@ -913,8 +913,7 @@ public class PaxosTest extends BaseJUnitTest {
 
         // From there, make sure the second command can be executed
         searchSettings.resetNetwork().clearGoals().addGoal(CLIENTS_DONE);
-        bfs(oneCommandExecuted);
-        assertGoalFound(oneCommandExecuted);
+        assertGoalReachableFrom(oneCommandExecuted);
 
         // Check that linearizability is preserved (with and without timers)
         searchSettings.clearGoals().addPrune(CLIENTS_DONE).maxTimeSecs(30);
@@ -967,13 +966,11 @@ public class PaxosTest extends BaseJUnitTest {
         // Check that second append can happen in both other partitions
         searchSettings.clearGoals().addGoal(CLIENTS_DONE).resetNetwork()
                       .partition(server(1), server(3), client(2));
-        bfs(firstAppendSent);
-        assertGoalFound(firstAppendSent);
+        assertGoalReachableFrom(firstAppendSent);
 
         searchSettings.resetNetwork()
                       .partition(server(2), server(3), client(2));
-        bfs(firstAppendSent);
-        assertGoalFound(firstAppendSent);
+        assertGoalReachableFrom(firstAppendSent);
 
         // Checking that linearizability is preserved in both other partitions
         searchSettings.clearGoals().addPrune(CLIENTS_DONE).resetNetwork()
@@ -1083,8 +1080,7 @@ public class PaxosTest extends BaseJUnitTest {
 
         // Make sure server 4 can get c1 chosen
         searchSettings.clearGoals().addGoal(hasStatus(server(4), 1, CHOSEN));
-        bfs(c1AtServer1);
-        assertGoalFound(c1AtServer1);
+        assertGoalReachableFrom(c1AtServer1);
 
         // Re-add ignored messages
         c1AtServer1.undropMessagesFrom(server(3));

--- a/labs/lab3-paxos/tst/dslabs/paxos/PaxosTest.java
+++ b/labs/lab3-paxos/tst/dslabs/paxos/PaxosTest.java
@@ -914,7 +914,7 @@ public class PaxosTest extends BaseJUnitTest {
         // From there, make sure the second command can be executed
         searchSettings.resetNetwork().clearGoals().addGoal(CLIENTS_DONE);
         bfs(oneCommandExecuted);
-        assertGoalFound();
+        assertGoalFound(oneCommandExecuted);
 
         // Check that linearizability is preserved (with and without timers)
         searchSettings.clearGoals().addPrune(CLIENTS_DONE).maxTimeSecs(30);
@@ -968,12 +968,12 @@ public class PaxosTest extends BaseJUnitTest {
         searchSettings.clearGoals().addGoal(CLIENTS_DONE).resetNetwork()
                       .partition(server(1), server(3), client(2));
         bfs(firstAppendSent);
-        assertGoalFound();
+        assertGoalFound(firstAppendSent);
 
         searchSettings.resetNetwork()
                       .partition(server(2), server(3), client(2));
         bfs(firstAppendSent);
-        assertGoalFound();
+        assertGoalFound(firstAppendSent);
 
         // Checking that linearizability is preserved in both other partitions
         searchSettings.clearGoals().addPrune(CLIENTS_DONE).resetNetwork()
@@ -1084,7 +1084,7 @@ public class PaxosTest extends BaseJUnitTest {
         // Make sure server 4 can get c1 chosen
         searchSettings.clearGoals().addGoal(hasStatus(server(4), 1, CHOSEN));
         bfs(c1AtServer1);
-        assertGoalFound();
+        assertGoalFound(c1AtServer1);
 
         // Re-add ignored messages
         c1AtServer1.undropMessagesFrom(server(3));

--- a/labs/lab3-paxos/tst/dslabs/paxos/PaxosTest.java
+++ b/labs/lab3-paxos/tst/dslabs/paxos/PaxosTest.java
@@ -908,8 +908,7 @@ public class PaxosTest extends BaseJUnitTest {
                       .addInvariant(RESULTS_OK)
                       .addInvariant(LOGS_CONSISTENT_ALL_SLOTS)
                       .addGoal(NONE_DECIDED.negate());
-        bfs(initSearchState);
-        final SearchState oneCommandExecuted = goalMatchingState();
+        final SearchState oneCommandExecuted = findGoalMatchingStateFrom(initSearchState);
 
         // From there, make sure the second command can be executed
         searchSettings.resetNetwork().clearGoals().addGoal(CLIENTS_DONE);
@@ -960,8 +959,7 @@ public class PaxosTest extends BaseJUnitTest {
                       .addInvariant(LOGS_CONSISTENT_ALL_SLOTS)
                       .addGoal(NONE_DECIDED.negate())
                       .partition(server(1), server(2), client(1));
-        bfs(initSearchState);
-        final SearchState firstAppendSent = goalMatchingState();
+        final SearchState firstAppendSent = findGoalMatchingStateFrom(initSearchState);
 
         // Check that second append can happen in both other partitions
         searchSettings.clearGoals().addGoal(CLIENTS_DONE).resetNetwork()
@@ -1032,12 +1030,10 @@ public class PaxosTest extends BaseJUnitTest {
                       .deliverTimers(server(5), false)
                       .deliverTimers(client(2), false)
                       .addGoal(hasCommand(server(4), 1, c1));
-        bfs(initSearchState);
-        final SearchState c1AtServer4 = goalMatchingState();
+        final SearchState c1AtServer4 = findGoalMatchingStateFrom(initSearchState);
 
         searchSettings.clearGoals().addGoal(hasCommand(server(3), 1, c1));
-        bfs(c1AtServer4);
-        final SearchState c1AtServer3 = goalMatchingState();
+        final SearchState c1AtServer3 = findGoalMatchingStateFrom(c1AtServer4);
 
         // Now, find a state where server 3 has client 2's command
         searchSettings.nodeActive(server(4), false).nodeActive(server(3), false)
@@ -1046,14 +1042,12 @@ public class PaxosTest extends BaseJUnitTest {
                       .deliverTimers(server(3), false)
                       .deliverTimers(client(1), false).clearGoals()
                       .addGoal(hasCommand(server(5), 1, c2));
-        bfs(c1AtServer3);
-        final SearchState c2AtServer5 = goalMatchingState();
+        final SearchState c2AtServer5 = findGoalMatchingStateFrom(c1AtServer3);
 
         searchSettings.nodeActive(server(3), true)
                       .deliverTimers(server(3), true).clearGoals()
                       .addGoal(hasCommand(server(3), 1, c2));
-        bfs(c2AtServer5);
-        final SearchState c2AtServer3 = goalMatchingState();
+        final SearchState c2AtServer3 = findGoalMatchingStateFrom(c2AtServer5);
 
         // Now, clear the prunes and find a state where server 2 has c1
         searchSettings.clear().maxTimeSecs(30).addInvariant(slotValid(1));
@@ -1075,8 +1069,7 @@ public class PaxosTest extends BaseJUnitTest {
                       .deliverTimers(server(3), false)
                       .deliverTimers(client(2), false)
                       .addGoal(hasCommand(server(1), 1, c1));
-        bfs(c2AtServer3);
-        final SearchState c1AtServer1 = goalMatchingState();
+        final SearchState c1AtServer1 = findGoalMatchingStateFrom(c2AtServer3);
 
         // Make sure server 4 can get c1 chosen
         searchSettings.clearGoals().addGoal(hasStatus(server(4), 1, CHOSEN));
@@ -1205,9 +1198,8 @@ public class PaxosTest extends BaseJUnitTest {
         initSearchState.addClientWorker(client(1), putAppendGetWorkload);
         searchSettings.clear().addInvariant(RESULTS_OK).addGoal(CLIENTS_DONE)
                       .maxTimeSecs(10).maxDepth(6).singleThreaded(true);
-        bfs(initSearchState);
 
-        final SearchState clientDone = goalMatchingState();
+        final SearchState clientDone = findGoalMatchingStateFrom(initSearchState);
         assertEquals(6, clientDone.depth());
 
         searchSettings.maxDepth(-1).clearGoals().addPrune(CLIENTS_DONE);

--- a/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStoreBaseTest.java
+++ b/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStoreBaseTest.java
@@ -227,7 +227,7 @@ public abstract class ShardStoreBaseTest extends BaseJUnitTest {
         // From there, make sure the client can finish all operations
         searchSettings.resetNetwork().clearGoals().addGoal(CLIENTS_DONE);
         bfs(joinFinished);
-        assertGoalFound();
+        assertGoalFound(joinFinished);
 
         // Now, check from the end of the Join
         searchSettings.clearGoals().addPrune(CLIENTS_DONE).maxTimeSecs(30);

--- a/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStoreBaseTest.java
+++ b/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStoreBaseTest.java
@@ -221,8 +221,7 @@ public abstract class ShardStoreBaseTest extends BaseJUnitTest {
         // First, just get the Join finished
         searchSettings.maxTimeSecs(15).partition(CCA, shardMaster(1))
                       .addInvariant(RESULTS_OK).addGoal(clientDone(CCA));
-        bfs(initSearchState);
-        final SearchState joinFinished = goalMatchingState();
+        final SearchState joinFinished = findGoalMatchingStateFrom(initSearchState);
 
         // From there, make sure the client can finish all operations
         searchSettings.resetNetwork().clearGoals().addGoal(CLIENTS_DONE);
@@ -251,21 +250,18 @@ public abstract class ShardStoreBaseTest extends BaseJUnitTest {
         searchSettings.maxTimeSecs(15).partition(CCA, shardMaster(1))
                       .addInvariant(RESULTS_OK)
                       .addGoal(clientHasResults(CCA, 1));
-        bfs(initSearchState);
-        final SearchState firstJoin = goalMatchingState();
+        final SearchState firstJoin = findGoalMatchingStateFrom(initSearchState);
 
         // Then, find a state where the Put is finished
         searchSettings.resetNetwork()
                       .partition(client(1), shardMaster(1), server(1, 1))
                       .clearGoals().addGoal(clientHasResults(client(1), 1));
-        bfs(firstJoin);
-        final SearchState putDone = goalMatchingState();
+        final SearchState putDone = findGoalMatchingStateFrom(firstJoin);
 
         // From there, finish the second Join and the Leave
         searchSettings.resetNetwork().partition(CCA, shardMaster(1))
                       .clearGoals().addGoal(clientDone(CCA));
-        bfs(putDone);
-        final SearchState ccaDone = goalMatchingState();
+        final SearchState ccaDone = findGoalMatchingStateFrom(putDone);
 
         // Search for invariant violations from there
         searchSettings.clearGoals().resetNetwork().addPrune(CLIENTS_DONE)
@@ -296,16 +292,14 @@ public abstract class ShardStoreBaseTest extends BaseJUnitTest {
         searchSettings.maxTimeSecs(15).partition(CCA, shardMaster(1))
                       .addInvariant(RESULTS_OK)
                       .addGoal(clientHasResults(CCA, 1));
-        bfs(initSearchState);
-        SearchState firstJoin = goalMatchingState();
+        SearchState firstJoin = findGoalMatchingStateFrom(initSearchState);
 
         // Find state where client1 is done
         searchSettings.resetNetwork()
                       .partition(client(1), shardMaster(1), server(1, 1))
                       .maxTimeSecs(30).clearGoals()
                       .addGoal(clientDone(client(1)));
-        bfs(firstJoin);
-        SearchState client1Done = goalMatchingState();
+        SearchState client1Done = findGoalMatchingStateFrom(firstJoin);
 
         // Make sure we can find a state where client2 has finished
         searchSettings.resetNetwork()
@@ -317,8 +311,7 @@ public abstract class ShardStoreBaseTest extends BaseJUnitTest {
         searchSettings.resetNetwork().maxTimeSecs(15)
                       .partition(CCA, shardMaster(1)).clearGoals()
                       .addGoal(clientDone(CCA));
-        bfs(client1Done);
-        SearchState secondJoin = goalMatchingState();
+        SearchState secondJoin = findGoalMatchingStateFrom(client1Done);
 
         // Search for invariant violations from second join being done
         searchSettings.clearGoals().resetNetwork().maxTimeSecs(30)

--- a/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStoreBaseTest.java
+++ b/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStoreBaseTest.java
@@ -226,8 +226,7 @@ public abstract class ShardStoreBaseTest extends BaseJUnitTest {
 
         // From there, make sure the client can finish all operations
         searchSettings.resetNetwork().clearGoals().addGoal(CLIENTS_DONE);
-        bfs(joinFinished);
-        assertGoalFound(joinFinished);
+        assertGoalReachableFrom(joinFinished);
 
         // Now, check from the end of the Join
         searchSettings.clearGoals().addPrune(CLIENTS_DONE).maxTimeSecs(30);


### PR DESCRIPTION
One of the more challenging test failures to debug is when a search-based "liveness" test fails, due to a BFS failing to find a goal state. Typically these BFS searches do not start in the initial state, but rather start from some previously computed state, e.g., the result of a BFS to find a state where a view has been fully initialized. Thus, students cannot simply open up the visual debugger and try to drive the system towards the failed goal, because they do not even know what the start state is.

I'm not really sure what students are expected to do in this situation. What I do when they come to me for help is manually edit the test file to print a trace to the starting state. Then I painstakingly manually replay this trace in the visual debugger (god help me when message are implicitly duplicated by the trace), and then *from there* I try to drive the system toward the final goal state, and understand why it fails to reach it. 

This PR prototypes a way to automate this strategy, by opening the visual debugger in the failed search's start state. This requires slightly more information be passed from the lab-specific test into the test framework, so that the framework knows what the start state is when the goal is not found. 

Our current implementation passes this start state as an additional parameter to the private version of `assertGoalFound`. We then provide wrappers for the tests to call that combine the bfs with the assertion that it finds a goal, called `findGoalMatchingStateFrom`. We would like feedback on this new API and are open to suggestions. 

See the commit messages for more detail.