### PR TITLE
Fix typo in lab 3 README

### DIFF
--- a/labs/lab3-paxos/README.md
+++ b/labs/lab3-paxos/README.md
@@ -201,7 +201,7 @@ You should pass the lab 3 tests; execute them with `./run-tests.py --lab 3`.
   more than one value for each slot on each node. You can then include both the
   accepted and decided values in P1B messages, speeding up the leader election
   process.
-* You might find the `Multimap` classes from Guava useful for storing P2B
+* You might find the `Multimap` classes from Guava useful for storing P1B
   messages for each slot.
 * Non-static inner classes implicitly contain a reference to the enclosing
   object. If they are serialized, this reference will be serialized as well.


### PR DESCRIPTION
According to PMMC, we only need to send `pvalues` containing the previously
accepted commands and ballots for each slot in P1B and adopted message.