### PR TITLE
Incorporate SearchSettings in the new debugger

### DIFF
--- a/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
+++ b/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
@@ -303,8 +303,9 @@ public abstract class BaseJUnitTest {
         }
 
         if (GlobalSettings.startVisualization()) {
+            final SearchSettings settings = searchSettings;
             Thread thread = new Thread(() -> {
-                VizClient vc = new VizClient(humanReadable, invariant, true);
+                VizClient vc = new VizClient(humanReadable, settings, true);
                 try {
                     vc.run();
                 } catch (IOException e) {
@@ -387,8 +388,9 @@ public abstract class BaseJUnitTest {
         if (GlobalSettings.startVisualization() && bfsStartState != null) {
             final SearchState humanReadable =
                 SearchState.humanReadableTraceEndState(bfsStartState);
+            final SearchSettings settings = searchSettings;
             Thread thread = new Thread(() -> {
-                VizClient vc = new VizClient(humanReadable, null, true);
+                VizClient vc = new VizClient(humanReadable, settings, true);
                 try {
                     vc.run();
                 } catch (IOException e) {

--- a/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
+++ b/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
@@ -242,7 +242,7 @@ public class DebuggerWindow extends JFrame {
             if (searchSettings != null) {
                 addPredicatePaneToSidebar(sideBar, "Invariants", searchSettings.invariants(),
                                           this.invariants);
-                addPredicatePaneToSidebar(sideBar, "Prunes", searchSettings.prunes(),
+                addPredicatePaneToSidebar(sideBar, "Prunes (Ignored States)", searchSettings.prunes(),
                                           this.prunes);
                 addPredicatePaneToSidebar(sideBar, "Goals", searchSettings.goals(),
                                           this.goals);
@@ -347,6 +347,7 @@ public class DebuggerWindow extends JFrame {
 
             if (invariant.test(currentState.state())) {
                 label.setIcon(Utils.makeIcon(FontAwesome.CHECK_SQUARE));
+                label.setToolTipText(null);
             } else {
                 label.setIcon(Utils.makeIcon(FontAwesome.EXCLAMATION_TRIANGLE,
                         UIManager.getColor("warningColor")));
@@ -359,13 +360,12 @@ public class DebuggerWindow extends JFrame {
             JLabel label = e.getValue();
 
             if (prune.test(currentState.state())) {
-                // Not sure what icon to put here: scissors? then what icon to use for the
-                // un-pruned?
-                label.setIcon(Utils.makeIcon(FontAwesome.LOCK,
-                        UIManager.getColor("warningColor")));
+                label.setIcon(Utils.makeIcon(FontAwesome.EYE_SLASH,
+                        Utils.desaturate(UIManager.getColor("warningColor"), 0.5)));
                 label.setToolTipText(prune.detail(currentState.state()));
             } else {
-                label.setIcon(Utils.makeIcon(FontAwesome.UNLOCK));
+                label.setIcon(Utils.makeIcon(FontAwesome.EYE));
+                label.setToolTipText(null);
             }
         }
 
@@ -376,6 +376,7 @@ public class DebuggerWindow extends JFrame {
             if (goal.test(currentState.state())) {
                 label.setIcon(Utils.makeIcon(FontAwesome.CHECK_CIRCLE,
                         UIManager.getColor("successColor")));
+                label.setToolTipText(null);
             } else {
                 // Not using an exclamation because even if the current state is not a goal,
                 // this isn't an error. FontAwesome apparently doesn't have a TIMES_SQUARE,

--- a/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
+++ b/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
@@ -256,7 +256,7 @@ public class DebuggerWindow extends JFrame {
             ADD THE NODES AND EVENT PANEL
            -------------------------------------------------------------------*/
         for (Address a : addresses) {
-            SingleNodePanel panel = new SingleNodePanel(currentState, a, this);
+            SingleNodePanel panel = new SingleNodePanel(currentState, searchSettings, a, this);
             statePanels.put(a, panel);
         }
 
@@ -473,7 +473,7 @@ public class DebuggerWindow extends JFrame {
         currentState = s;
         for (Address a : currentState.addresses()) {
             assert statePanels.containsKey(a);
-            statePanels.get(a).updateState(currentState, viewDeliveredMessages);
+            statePanels.get(a).updateState(currentState, searchSettings, viewDeliveredMessages);
         }
         eventsPanel.update(currentState);
         updatePredicatePanes();

--- a/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
+++ b/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
@@ -26,8 +26,8 @@ import com.google.common.collect.Lists;
 import dslabs.framework.Address;
 import dslabs.framework.testing.Event;
 import dslabs.framework.testing.StatePredicate;
-import dslabs.framework.testing.search.SearchState;
 import dslabs.framework.testing.search.SearchSettings;
+import dslabs.framework.testing.search.SearchState;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.event.ActionEvent;
@@ -99,7 +99,8 @@ public class DebuggerWindow extends JFrame {
     private final Map<Address, SingleNodePanel> statePanels = new HashMap<>();
     private final Map<Address, JCheckBox> nodesActive = new HashMap<>();
 
-    private final List<Pair<StatePredicate, JLabel>> invariants = new ArrayList<>();
+    private final List<Pair<StatePredicate, JLabel>> invariants =
+            new ArrayList<>();
     private final List<Pair<StatePredicate, JLabel>> prunes = new ArrayList<>();
     private final List<Pair<StatePredicate, JLabel>> goals = new ArrayList<>();
 
@@ -181,17 +182,23 @@ public class DebuggerWindow extends JFrame {
                 }
             });
 
-            JCheckBoxMenuItem ignoreSearchSettingsMenuItem =
-                    new JCheckBoxMenuItem("Ignore search requirements", false);
-            settingsMenu.add(ignoreSearchSettingsMenuItem);
-            ignoreSearchSettingsMenuItem.addActionListener(e -> {
-                boolean old = ignoreSearchSettings;
-                ignoreSearchSettings =
-                        ignoreSearchSettingsMenuItem.getState();
-                if (old != ignoreSearchSettings) {
-                    setState(currentState);
-                }
-            });
+            // TODO: only add menu item if searchSettings actually restricts events
+            // (has prunes or prevents message/timer delivery)
+            if (searchSettings != null) {
+                JCheckBoxMenuItem ignoreSearchSettingsMenuItem =
+                        new JCheckBoxMenuItem(
+                                "Ignore search event delivery restrictions",
+                                false);
+                settingsMenu.add(ignoreSearchSettingsMenuItem);
+                ignoreSearchSettingsMenuItem.addActionListener(e -> {
+                    boolean old = ignoreSearchSettings;
+                    ignoreSearchSettings =
+                            ignoreSearchSettingsMenuItem.getState();
+                    if (old != ignoreSearchSettings) {
+                        setState(currentState);
+                    }
+                });
+            }
 
             settingsMenu.addSeparator();
 
@@ -253,12 +260,12 @@ public class DebuggerWindow extends JFrame {
             sideBar.add(viewHidePane);
 
             if (searchSettings != null) {
-                addPredicatePaneToSidebar(sideBar, "Invariants", searchSettings.invariants(),
-                                          this.invariants);
-                addPredicatePaneToSidebar(sideBar, "Prunes (Ignored States)", searchSettings.prunes(),
-                                          this.prunes);
-                addPredicatePaneToSidebar(sideBar, "Goals", searchSettings.goals(),
-                                          this.goals);
+                addPredicatePaneToSidebar(sideBar, "Invariants",
+                        searchSettings.invariants(), this.invariants);
+                addPredicatePaneToSidebar(sideBar, "Prunes (Ignored States)",
+                        searchSettings.prunes(), this.prunes);
+                addPredicatePaneToSidebar(sideBar, "Goals",
+                        searchSettings.goals(), this.goals);
                 updatePredicatePanes();
             }
             sideBar.setMinimumSize(new Dimension(20, 0));
@@ -269,7 +276,8 @@ public class DebuggerWindow extends JFrame {
             ADD THE NODES AND EVENT PANEL
            -------------------------------------------------------------------*/
         for (Address a : addresses) {
-            SingleNodePanel panel = new SingleNodePanel(currentState, searchSettings, a, this);
+            SingleNodePanel panel =
+                    new SingleNodePanel(currentState, searchSettings, a, this);
             statePanels.put(a, panel);
         }
 
@@ -337,7 +345,8 @@ public class DebuggerWindow extends JFrame {
         setVisible(true);
     }
 
-    private void addPredicatePaneToSidebar(JXTaskPaneContainer sideBar, String name,
+    private void addPredicatePaneToSidebar(JXTaskPaneContainer sideBar,
+                                           String name,
                                            Collection<StatePredicate> predicates,
                                            List<Pair<StatePredicate, JLabel>> labels) {
         if (predicates.isEmpty()) {
@@ -374,9 +383,11 @@ public class DebuggerWindow extends JFrame {
 
             if (prune.test(currentState.state())) {
                 label.setIcon(Utils.makeIcon(FontAwesome.EYE_SLASH,
-                        Utils.desaturate(UIManager.getColor("warningColor"), 0.5)));
+                        Utils.desaturate(UIManager.getColor("warningColor"),
+                                0.5)));
                 label.setToolTipText(prune.detail(currentState.state()));
             } else {
+                // TODO: find better icons, the eye staring at you is creepy
                 label.setIcon(Utils.makeIcon(FontAwesome.EYE));
                 label.setToolTipText(null);
             }
@@ -488,11 +499,10 @@ public class DebuggerWindow extends JFrame {
         for (Address a : currentState.addresses()) {
             assert statePanels.containsKey(a);
             statePanels.get(a).updateState(currentState,
-                                           ignoreSearchSettings ? null : searchSettings,
-                                           viewDeliveredMessages);
+                    ignoreSearchSettings ? null : searchSettings,
+                    viewDeliveredMessages);
         }
         eventsPanel.update(currentState);
         updatePredicatePanes();
     }
 }
-

--- a/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
+++ b/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
@@ -113,6 +113,7 @@ public class DebuggerWindow extends JFrame {
     private final SearchSettings searchSettings;
 
     private boolean viewDeliveredMessages = false;
+    private boolean ignoreSearchSettings = false;
 
     public DebuggerWindow(final SearchState initialState) {
         this(initialState, null);
@@ -165,12 +166,12 @@ public class DebuggerWindow extends JFrame {
             fileMenu.add(closeButton);
             closeButton.addActionListener(e -> DebuggerWindow.this.dispose());
 
-            final JMenu viewMenu = new JMenu("View");
-            menuBar.add(viewMenu);
+            final JMenu settingsMenu = new JMenu("Settings");
+            menuBar.add(settingsMenu);
 
             JCheckBoxMenuItem viewDeliveredMessagesMenuItem =
-                    new JCheckBoxMenuItem("View delivered messages", false);
-            viewMenu.add(viewDeliveredMessagesMenuItem);
+                    new JCheckBoxMenuItem("Show delivered messages", false);
+            settingsMenu.add(viewDeliveredMessagesMenuItem);
             viewDeliveredMessagesMenuItem.addActionListener(e -> {
                 boolean old = viewDeliveredMessages;
                 viewDeliveredMessages =
@@ -180,17 +181,29 @@ public class DebuggerWindow extends JFrame {
                 }
             });
 
-            viewMenu.addSeparator();
+            JCheckBoxMenuItem ignoreSearchSettingsMenuItem =
+                    new JCheckBoxMenuItem("Ignore search requirements", false);
+            settingsMenu.add(ignoreSearchSettingsMenuItem);
+            ignoreSearchSettingsMenuItem.addActionListener(e -> {
+                boolean old = ignoreSearchSettings;
+                ignoreSearchSettings =
+                        ignoreSearchSettingsMenuItem.getState();
+                if (old != ignoreSearchSettings) {
+                    setState(currentState);
+                }
+            });
+
+            settingsMenu.addSeparator();
 
             final ButtonGroup viewModeButtonGroup = new ButtonGroup();
             final JRadioButtonMenuItem lightMode =
                     new JRadioButtonMenuItem("Light theme", !darkModeEnabled);
             viewModeButtonGroup.add(lightMode);
-            viewMenu.add(lightMode);
+            settingsMenu.add(lightMode);
             final JRadioButtonMenuItem darkMode =
                     new JRadioButtonMenuItem("Dark theme", darkModeEnabled);
             viewModeButtonGroup.add(darkMode);
-            viewMenu.add(darkMode);
+            settingsMenu.add(darkMode);
 
             darkMode.addActionListener(e -> Utils.setupDarkTheme(true));
             lightMode.addActionListener(e -> Utils.setupLightTheme(true));
@@ -474,7 +487,9 @@ public class DebuggerWindow extends JFrame {
         currentState = s;
         for (Address a : currentState.addresses()) {
             assert statePanels.containsKey(a);
-            statePanels.get(a).updateState(currentState, searchSettings, viewDeliveredMessages);
+            statePanels.get(a).updateState(currentState,
+                                           ignoreSearchSettings ? null : searchSettings,
+                                           viewDeliveredMessages);
         }
         eventsPanel.update(currentState);
         updatePredicatePanes();

--- a/framework/tst/dslabs/framework/testing/newviz/FlatLaf.properties
+++ b/framework/tst/dslabs/framework/testing/newviz/FlatLaf.properties
@@ -8,6 +8,7 @@ newTreeCellStateColor=desaturate(@dslabsGreen, 30%)
 changedTreeCellStateColor=desaturate(@dslabsYellow, 30%)
 
 # TODO: figure out how to have a light/dark version and get icons to update dynamically
+successColor=#00BB00
 warningColor=#BB0000
 
 TaskPaneContainer.background=@background

--- a/framework/tst/dslabs/framework/testing/newviz/SingleNodePanel.java
+++ b/framework/tst/dslabs/framework/testing/newviz/SingleNodePanel.java
@@ -29,7 +29,6 @@ import dslabs.framework.testing.MessageEnvelope;
 import dslabs.framework.testing.TimerEnvelope;
 import dslabs.framework.testing.search.SearchSettings;
 import java.awt.Graphics;
-import java.awt.Component;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,8 +65,8 @@ class SingleNodePanel extends JPanel {
     private final List<Triple<TimerEnvelope, JPanel, StateTree>> timers =
             new ArrayList<>();
 
-    SingleNodePanel(final EventTreeState s, final SearchSettings settings, final Address a,
-                    final DebuggerWindow parent) {
+    SingleNodePanel(final EventTreeState s, final SearchSettings settings,
+                    final Address a, final DebuggerWindow parent) {
         this.parent = parent;
         address = a;
 
@@ -121,7 +120,8 @@ class SingleNodePanel extends JPanel {
     }
 
     // TODO: do this _much_ more incrementally without repainting everything
-    void updateState(EventTreeState s, SearchSettings settings, boolean viewDeliveredMessages) {
+    void updateState(EventTreeState s, SearchSettings settings,
+                     boolean viewDeliveredMessages) {
         boolean nodeIsDiffed = !s.isInitialState() &&
                 s.previousEvent().locationRootAddress().equals(address);
         if (nodeIsDiffed) {
@@ -144,7 +144,8 @@ class SingleNodePanel extends JPanel {
             if (messages.containsKey(message)) {
                 continue;
             }
-            addMessage(message, pruned, settings != null && !settings.shouldDeliver(message));
+            addMessage(message, pruned,
+                    settings != null && !settings.shouldDeliver(message));
             repaintMessageBox = true;
         }
         for (MessageEnvelope message : new HashSet<>(messages.keySet())) {
@@ -154,8 +155,8 @@ class SingleNodePanel extends JPanel {
                 messages.remove(message);
             } else {
                 setDeliverability(messages.get(message).getLeft(), pruned,
-                                  settings != null && !settings.shouldDeliver(message),
-                                  "message");
+                        settings != null && !settings.shouldDeliver(message),
+                        "message");
             }
         }
         if (repaintMessageBox) {
@@ -190,14 +191,15 @@ class SingleNodePanel extends JPanel {
 
         for (TimerEnvelope timer : s.timers(address)) {
             addTimer(timer, s.canStepTimer(timer), pruned,
-                     settings != null && !settings.deliverTimers(address));
+                    settings != null && !settings.deliverTimers(address));
         }
 
         timerBox.revalidate();
         timerBox.repaint();
     }
 
-    private void addMessage(final MessageEnvelope message, boolean pruned, boolean prohibited) {
+    private void addMessage(final MessageEnvelope message, boolean pruned,
+                            boolean prohibited) {
         final JPanel mbox =
                 new JPanel(new MigLayout(null, null, new AC().align("top")));
 
@@ -217,8 +219,8 @@ class SingleNodePanel extends JPanel {
         messageBox.add(mbox, "pad 0 0");
     }
 
-    private void addTimer(final TimerEnvelope timer, boolean deliverable, boolean pruned,
-                          boolean prohibited) {
+    private void addTimer(final TimerEnvelope timer, boolean deliverable,
+                          boolean pruned, boolean prohibited) {
         final JPanel tbox =
                 new JPanel(new MigLayout(null, null, new AC().align("top")));
 
@@ -244,16 +246,16 @@ class SingleNodePanel extends JPanel {
         timerBox.add(tbox);
     }
 
-    private void setDeliverability(JButton deliveryButton, boolean pruned, boolean prohibited,
-                                   String name) {
+    private void setDeliverability(JButton deliveryButton, boolean pruned,
+                                   boolean prohibited, String name) {
         deliveryButton.setEnabled(!pruned && !prohibited);
         String tooltip;
         if (pruned) {
             tooltip = "This " + name +
-                      " cannot be delivered because the current state is pruned by the search";
+                    " cannot be delivered because the current state is pruned by the search";
         } else if (prohibited) {
             tooltip = "This " + name +
-                      " cannot be delivered because delivery is prohibited by the search";
+                    " cannot be delivered because delivery is prohibited by the search";
         } else {
             tooltip = "Deliver " + name;
         }

--- a/framework/tst/dslabs/framework/testing/newviz/Utils.java
+++ b/framework/tst/dslabs/framework/testing/newviz/Utils.java
@@ -61,9 +61,11 @@ abstract class Utils {
 
     static Color desaturate(Color c, double factor) {
         if (factor < 0 || factor > 1) {
-            throw new IllegalArgumentException("factor to desaturate by must be between 0 and 1");
+            throw new IllegalArgumentException(
+                    "factor to desaturate by must be between 0 and 1");
         }
-        float hsb[] = Color.RGBtoHSB(c.getRed(), c.getGreen(), c.getBlue(), null);
+        float[] hsb =
+                Color.RGBtoHSB(c.getRed(), c.getGreen(), c.getBlue(), null);
         hsb[1] *= factor;
         return new Color(Color.HSBtoRGB(hsb[0], hsb[1], hsb[2]));
     }

--- a/framework/tst/dslabs/framework/testing/newviz/Utils.java
+++ b/framework/tst/dslabs/framework/testing/newviz/Utils.java
@@ -59,6 +59,15 @@ abstract class Utils {
                 c.getBlue());
     }
 
+    static Color desaturate(Color c, double factor) {
+        if (factor < 0 || factor > 1) {
+            throw new IllegalArgumentException("factor to desaturate by must be between 0 and 1");
+        }
+        float hsb[] = Color.RGBtoHSB(c.getRed(), c.getGreen(), c.getBlue(), null);
+        hsb[1] *= factor;
+        return new Color(Color.HSBtoRGB(hsb[0], hsb[1], hsb[2]));
+    }
+
     static boolean setupThemeOnStartup() {
         final Preferences prefs = Preferences.userNodeForPackage(Utils.class);
         final boolean darkModeEnabled = prefs.getBoolean(PREF_DARK_MODE, false);

--- a/framework/tst/dslabs/framework/testing/visualization/VizClient.java
+++ b/framework/tst/dslabs/framework/testing/visualization/VizClient.java
@@ -141,11 +141,7 @@ public class VizClient {
 
     public void run(Boolean startOddity) throws IOException {
         if (GlobalSettings.newViz()) {
-            if (invariant != null) {
-                new DebuggerWindow(state, Set.of(invariant));
-            } else {
-                new DebuggerWindow(state);
-            }
+            new DebuggerWindow(state, settings);
             return;
         }
 

--- a/framework/tst/dslabs/framework/testing/visualization/VizClient.java
+++ b/framework/tst/dslabs/framework/testing/visualization/VizClient.java
@@ -29,6 +29,7 @@ import dslabs.framework.testing.MessageEnvelope;
 import dslabs.framework.testing.StatePredicate;
 import dslabs.framework.testing.TimerEnvelope;
 import dslabs.framework.testing.newviz.DebuggerWindow;
+import dslabs.framework.testing.search.SearchSettings;
 import dslabs.framework.testing.search.SearchState;
 import dslabs.framework.testing.utils.GlobalSettings;
 import dslabs.framework.testing.utils.Json;
@@ -73,24 +74,26 @@ public class VizClient {
     private DataOutputStream out;
 
     private final SearchState state;
+    private final SearchSettings settings;
     private final StatePredicate invariant;
     private final String[] nodeNames;
     private final boolean trace;
 
     public VizClient(String host, int port, SearchState state,
-                     StatePredicate invariant, String[] nodeNames,
+                     SearchSettings settings, String[] nodeNames,
                      boolean trace) {
         this.host = host;
         this.port = port;
         this.state = state;
-        this.invariant = invariant;
+        this.settings = settings;
+        this.invariant = settings == null ? null : settings.whichInvariantViolated(state);
         this.nodeNames = nodeNames;
         this.trace = trace;
     }
 
-    public VizClient(SearchState state, StatePredicate invariant,
+    public VizClient(SearchState state, SearchSettings settings,
                      boolean trace) {
-        this(DEFAULT_HOST, DEFAULT_PORT, state, invariant,
+        this(DEFAULT_HOST, DEFAULT_PORT, state, settings,
                 Streams.stream(state.addresses()).map(Object::toString)
                        .toArray(String[]::new), trace);
     }


### PR DESCRIPTION
As described in https://github.com/emichael/dslabs/pull/20#issuecomment-1039365182, search tests often have settings to prevent some traces from being explored (e.g., by prunes, by declaring links/nodes inactive, by not delivering timers for some nodes, etc.). This change enforces the SearchSettings specified in a search test to help students to debug the search-based liveness tests.

This change is done in 3 parts.
- The VizClient must be given the SearchSettings so that it can give them to the DebuggerWindow. This is done in https://github.com/emichael/dslabs/commit/58d6be91f26826b0adf791111e18cb727946e239.
- The DebuggerWindow must accept the SearchSettings and show the prunes and goals to the left hand side. This is done in https://github.com/emichael/dslabs/commit/333c63c6a1ebd73946c5a4b2d1aa919d25d167af.
- In a SingleNodePanel, actions which are prohibited according to SearchSettings must be impossible to take. Moreover, if the search reaches an end state (goal matched, invariant violated, or prune reached), all actions should be impossible to take. This is done in https://github.com/emichael/dslabs/commit/d451e7269675d62f63e5e96a26f80d3e3d2743f3.

NOTES:

- Commits https://github.com/emichael/dslabs/commit/58d6be91f26826b0adf791111e18cb727946e239 and https://github.com/emichael/dslabs/commit/333c63c6a1ebd73946c5a4b2d1aa919d25d167af remove unused constructors and replace data structures. The commit messages explain why these changes were made, but they're not necessary for incorporating SearchSettings.
- This change doesn't yet add tooltips to explain why the messages cannot be delivered. At the moment, I don't see how to use the `SearchSettings` to get a string explanation of why a message/timer can't be delivered. But we should eventually add tooltips to explain why some messages/timers aren't deliverable.
- This change doesn't take the dropped network into account.We only `dropPendingMessages` in two tests in lab 3, so I think it's lower priority compared to this.

TESTS: manually started the debugger from various search test failures and confirmed that the invariant pane and actions behave correctly. I aimed to check the following:

- Goal pane behaves correctly: in [ping-pong's search test](https://github.com/emichael/dslabs/blob/633785340430c00f008569cf6cf169fcbd37cbb2/labs/lab0-pingpong/tst/dslabs/pingpong/PingTest.java#L122), I set the search to send 2 commands with a maxDepth of 2; when the search failed, I checked that we could navigate to a state where all workloads finished, that the goal pane on the left shows that All clients' workloads are finished, and that no actions can be taken in the debugger. 
- Invariant violation pane behaves correctly: with the same modifications to the pingpong search, I modified the client to not check received pong values. I checked that we could navigate to a state with an invariant violation, that the invariant pane on the left shows that the client did not receive the expected results, and that no actions can be taken in the debugger. I also checked that from the original search test (no depth restriction), if we don't check pong values in the client, the debugger shows the invariant violated and prevents any actions from being taken in the state with an invariant violation.
- Prune pane behaves correctly: from a valid solution to lab 2, I modified the client to never send results to clients. Running [part 2 test 17](https://github.com/emichael/dslabs/blob/d57df4281411a723e074bc467197bf06b01230f5/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java#L700), I checked that if we take a sequence that causes the ViewServer to send a view with viewNum=3, then the debugger shows that the prune was reached and prevents actions from being taken.
- Messages on inactive links are not deliverable: same test as above, server3 is marked inactive by the test, and no messages from server 3 are deliverable.
- Timers on requested nodes are undeliverable: I took a valid solution to lab 3 and modified [test 23](https://github.com/emichael/dslabs/blob/dd15351e5fdf92491ffc93b7d3bce617196c06f5/labs/lab3-paxos/tst/dslabs/paxos/PaxosTest.java#L1001) to have a maxDepth of 1. I confirmed that timers on servers 1,2,5 were not deliverable.