### PR TITLE
Use most recent SearchSettings in new debugger

### DIFF
--- a/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
+++ b/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
@@ -66,7 +66,7 @@ public abstract class BaseJUnitTest {
     /* Settings */
     protected RunSettings runSettings;
     protected SearchSettings searchSettings;
-    private SearchSettings bfsSettings;
+    private SearchSettings lastSearchSettings;
 
     /* States */
     protected RunState runState;
@@ -156,7 +156,7 @@ public abstract class BaseJUnitTest {
                         cleanupTest();
                         runSettings = null;
                         searchSettings = null;
-                        bfsSettings = null;
+                        lastSearchSettings = null;
                         runState = null;
                         initSearchState = null;
                         bfsStartState = null;
@@ -254,7 +254,7 @@ public abstract class BaseJUnitTest {
                              SearchSettings searchSettings) {
         assert searchState != null;
         bfsStartState = searchState;
-        bfsSettings = searchSettings;
+        lastSearchSettings = searchSettings;
         searchResults = Search.bfs(searchState, searchSettings);
         assertEndConditionValid();
     }
@@ -266,6 +266,7 @@ public abstract class BaseJUnitTest {
     protected final void dfs(SearchState searchState,
                              SearchSettings searchSettings) {
         assert searchState != null;
+        lastSearchSettings = searchSettings;
         searchResults = Search.dfs(searchState, searchSettings);
         assertEndConditionValid();
     }
@@ -306,7 +307,7 @@ public abstract class BaseJUnitTest {
         }
 
         if (GlobalSettings.startVisualization()) {
-            final SearchSettings settings = bfsSettings;
+            final SearchSettings settings = lastSearchSettings;
             Thread thread = new Thread(() -> {
                 VizClient vc = new VizClient(humanReadable, settings, true);
                 try {
@@ -391,7 +392,7 @@ public abstract class BaseJUnitTest {
         if (GlobalSettings.startVisualization() && bfsStartState != null) {
             final SearchState humanReadable =
                 SearchState.humanReadableTraceEndState(bfsStartState);
-            final SearchSettings settings = bfsSettings;
+            final SearchSettings settings = lastSearchSettings;
             Thread thread = new Thread(() -> {
                 VizClient vc = new VizClient(humanReadable, settings, true);
                 try {

--- a/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
+++ b/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
@@ -66,6 +66,7 @@ public abstract class BaseJUnitTest {
     /* Settings */
     protected RunSettings runSettings;
     protected SearchSettings searchSettings;
+    private SearchSettings bfsSettings;
 
     /* States */
     protected RunState runState;
@@ -155,6 +156,7 @@ public abstract class BaseJUnitTest {
                         cleanupTest();
                         runSettings = null;
                         searchSettings = null;
+                        bfsSettings = null;
                         runState = null;
                         initSearchState = null;
                         bfsStartState = null;
@@ -252,6 +254,7 @@ public abstract class BaseJUnitTest {
                              SearchSettings searchSettings) {
         assert searchState != null;
         bfsStartState = searchState;
+        bfsSettings = searchSettings;
         searchResults = Search.bfs(searchState, searchSettings);
         assertEndConditionValid();
     }
@@ -303,7 +306,7 @@ public abstract class BaseJUnitTest {
         }
 
         if (GlobalSettings.startVisualization()) {
-            final SearchSettings settings = searchSettings;
+            final SearchSettings settings = bfsSettings;
             Thread thread = new Thread(() -> {
                 VizClient vc = new VizClient(humanReadable, settings, true);
                 try {
@@ -388,7 +391,7 @@ public abstract class BaseJUnitTest {
         if (GlobalSettings.startVisualization() && bfsStartState != null) {
             final SearchState humanReadable =
                 SearchState.humanReadableTraceEndState(bfsStartState);
-            final SearchSettings settings = searchSettings;
+            final SearchSettings settings = bfsSettings;
             Thread thread = new Thread(() -> {
                 VizClient vc = new VizClient(humanReadable, settings, true);
                 try {


### PR DESCRIPTION
For searches that use one-off SearchSettings, the `searchSettings` field of the BaseJUnitTest won't have the required information. For example, see [`initView`](https://github.com/emichael/dslabs/blob/d57df4281411a723e074bc467197bf06b01230f5/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java#L161-L172) of lab 2: since we're using the settings in the BaseJUnitTest, the debugger will open but there won't be any settings.

The fix is to save the settings used in the last search, similar to https://github.com/emichael/dslabs/pull/20#discussion_r803341651; this time we need to save the settings from both BFS and DFS.

Tested: 
* repeated the prune pane test from https://github.com/emichael/dslabs/pull/29. 
* modified the ViewServer to never add a backup even if there was an idle server available, and ensured that the correct prunes and goals are shown when the test fails on `initView`.
* modified the ViewServer to handle acknowledgements incorrectly, and confirmed that when lab 2 part 2 test 20 fails, the debugger shows that the invariant is violated