### PR TITLE
Line wrap predicate names

### DIFF
--- a/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
+++ b/framework/tst/dslabs/framework/testing/newviz/DebuggerWindow.java
@@ -93,6 +93,7 @@ public class DebuggerWindow extends JFrame {
 
     static final String WINDOW_TITLE = "DSLabs Visual Debugger";
     static final int WINDOW_DEFAULT_WIDTH = 1440, WINDOW_DEFAULT_HEIGHT = 810;
+    static final String LINE_WRAPPING_FORMAT = "<html>%1s";
 
     private final Address[] addresses;
 
@@ -355,7 +356,7 @@ public class DebuggerWindow extends JFrame {
 
         JXTaskPane pane = new JXTaskPane(name);
         for (StatePredicate predicate : predicates) {
-            JLabel label = new JLabel(predicate.name());
+            JLabel label = new JLabel(String.format(LINE_WRAPPING_FORMAT, predicate.name()));
             pane.add(label);
             labels.add(Pair.of(predicate, label));
         }


### PR DESCRIPTION
See the first part of https://github.com/emichael/dslabs/projects/1#card-80283420.

Tested: ran some tests to get invariant violations and liveness violations, and confirmed that the predicate names wrap as the left sidebar is resized.