### PR TITLE
Add java source files as a dependency for submit.tar.gz

### DIFF
--- a/handout-files/Makefile
+++ b/handout-files/Makefile
@@ -43,7 +43,7 @@ $(OUT)/tst/: $(JAVA_TST) $(OUT)/src
 	@ $(JC) -d $@ -cp "$(TST_JARS)$(SEP)$(OUT)/src" $(JAVA_TST)
 
 
-submit.tar.gz:
+submit.tar.gz: $(JAVA_SRC)
 	@ echo "[tar] submit.tar.gz"
 	@ tar -cvzf $@ labs/*/src
 


### PR DESCRIPTION
Previously, to generate the submit tar, you have to explicitly `rm submit.tar.gz` or `make clean` because the target has no dependencies in the Makefile (maybe there's a reason why this is the case). This change adds the dependency of JAVA_SRC to the submit tar.

For 452, the only non-java-source files in the tar are writeup files, which we have a separate submission for, and therefore I think they shouldn't be included as a dependency in the Makefile.