### PR TITLE
Add lombok annotations for ShardStoreNode

### DIFF
--- a/labs/lab4-shardedstore/src/dslabs/shardkv/ShardStoreNode.java
+++ b/labs/lab4-shardedstore/src/dslabs/shardkv/ShardStoreNode.java
@@ -9,9 +9,7 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.ToString;
 
-@ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 abstract class ShardStoreNode extends Node {
     @Getter(AccessLevel.PACKAGE) private final Address[] shardMasters;

--- a/labs/lab4-shardedstore/src/dslabs/shardkv/ShardStoreNode.java
+++ b/labs/lab4-shardedstore/src/dslabs/shardkv/ShardStoreNode.java
@@ -6,9 +6,13 @@ import dslabs.framework.Node;
 import java.util.Collections;
 import java.util.LinkedList;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.ToString;
 
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 abstract class ShardStoreNode extends Node {
     @Getter(AccessLevel.PACKAGE) private final Address[] shardMasters;
     private final int numShards;


### PR DESCRIPTION
Just helped debug a student solution who put some states into `ShatdStoreNode`, and this diff solved it. The situation was quite frustrating: all tests except BFS can pass, BFS failed by running out of time when searching goal state (so there's no valuable trace). The goal state seems to be missed because of non-deterministic caused by incorrect equal and hash methods, but `--checks` reports nothing, and I'm not sure why. Maybe it need to be fixed as well.

README currently says nothing about we cannot put states into `ShardStoreNode`. While stating that is an alternative approach, I feel it would be better if we can offer more flexibility to students.

The annotations do not break my own solution, and I think it probably will not break any other reasonable solution.