### PR TITLE
Fixed string format error in lab4 part1 tests

### DIFF
--- a/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStorePart1Test.java
+++ b/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStorePart1Test.java
@@ -262,13 +262,13 @@ public final class ShardStorePart1Test extends ShardStoreBaseTest {
                         if (e.getValue().isEmpty() &&
                                 group2Clients.contains(a)) {
                             return new ImmutablePair<>(false, String.format(
-                                    "%s is a client of group 2 but could not complete operation"));
+                                    "%s is a client of group 2 but could not complete operation", a));
                         }
 
                         if (!e.getValue().isEmpty() &&
                                 group1Clients.contains(a)) {
                             return new ImmutablePair<>(false, String.format(
-                                    "%s is a client of group 1 but could complete operation"));
+                                    "%s is a client of group 1 but could complete operation", a));
                         }
                     }
                     return TRUE_NO_MESSAGE;


### PR DESCRIPTION
Noticed while working on the lab that these two string format calls were missing their arguments.