### PR TITLE
Compute client waiting time without including testing framework time

### DIFF
--- a/framework/tst/dslabs/framework/testing/ClientWorker.java
+++ b/framework/tst/dslabs/framework/testing/ClientWorker.java
@@ -118,11 +118,14 @@ public final class ClientWorker extends Node {
         sendNextCommandWhilePossible();
     }
 
-    public synchronized long maxWaitTimeMilis() {
+    public synchronized void markEndTimeOfOutstandingRequest() {
         if (waitingOnResult) {
-            return max(maxWaitTimeMillis,
+            maxWaitTimeMillis = max(maxWaitTimeMillis,
                     System.currentTimeMillis() - lastSendTimeMillis);
         }
+    }
+
+    public synchronized long maxWaitTimeMillis() {
         return maxWaitTimeMillis;
     }
 

--- a/framework/tst/dslabs/framework/testing/runner/RunState.java
+++ b/framework/tst/dslabs/framework/testing/runner/RunState.java
@@ -304,9 +304,9 @@ public class RunState extends AbstractState {
     }
 
     /**
-     * Must be synchronized and running in multi-threaded mode when called.
-     *
      * Starts a thread for a given node and adds it to runningThreads.
+     * <p>
+     * Must be synchronized and running in multi-threaded mode when called.
      *
      * @param address
      *         the address of the node to start
@@ -340,6 +340,7 @@ public class RunState extends AbstractState {
         }
 
         // Wait on all threads
+        long prewait = System.currentTimeMillis();
         try {
             while (mainThread != null || !nodeThreads.isEmpty()) {
                 wait();
@@ -347,6 +348,11 @@ public class RunState extends AbstractState {
         } finally {
             shuttingDown = false;
             notifyAll();
+        }
+
+        long timeWaited = System.currentTimeMillis() - prewait;
+        if (timeWaited >= 1000) {
+            LOG.warning(() -> "Took more than one second (" + timeWaited +  "ms) to shutdown threads. This likely indicates a performance bug in your system where a single message/timer takes more than a second to process.");
         }
 
         running = false;

--- a/labs/lab1-clientserver/tst/dslabs/clientserver/ClientServerPart2Test.java
+++ b/labs/lab1-clientserver/tst/dslabs/clientserver/ClientServerPart2Test.java
@@ -175,6 +175,7 @@ public final class ClientServerPart2Test extends ClientServerBaseTest {
         // Let the clients run
         runSettings.maxTimeSecs(testLengthSecs);
         runState.run(runSettings);
+        markEndTimeOfAnyOutstandingRequests();
 
         // Check if all the results were right
         runSettings.addInvariant(RESULTS_OK);

--- a/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java
+++ b/labs/lab2-primarybackup/tst/dslabs/primarybackup/PrimaryBackupTest.java
@@ -652,6 +652,7 @@ public class PrimaryBackupTest extends BaseJUnitTest {
 
         // Let the clients run
         Thread.sleep(testLengthSecs * 1000);
+        markEndTimeOfAnyOutstandingRequests();
 
         // Shut the clients down
         shutdownStartedThreads();

--- a/labs/lab3-paxos/tst/dslabs/paxos/PaxosTest.java
+++ b/labs/lab3-paxos/tst/dslabs/paxos/PaxosTest.java
@@ -728,6 +728,7 @@ public class PaxosTest extends BaseJUnitTest {
         // Heal the partition
         runSettings.reconnect();
         Thread.sleep(5000);
+        markEndTimeOfAnyOutstandingRequests();
 
         // Shut the clients down
         runState.stop();
@@ -789,6 +790,7 @@ public class PaxosTest extends BaseJUnitTest {
         // Let the clients run
         runState.start(runSettings);
         Thread.sleep(testLengthSecs * 1000);
+        markEndTimeOfAnyOutstandingRequests();
 
         // Shut the clients down
         shutdownStartedThreads();

--- a/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStorePart1Test.java
+++ b/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStorePart1Test.java
@@ -345,6 +345,7 @@ public final class ShardStorePart1Test extends ShardStoreBaseTest {
 
         // Let the clients run
         Thread.sleep(testLengthSecs * 1000);
+        markEndTimeOfAnyOutstandingRequests();
 
         // Shut the clients down
         shutdownStartedThreads();
@@ -384,6 +385,7 @@ public final class ShardStorePart1Test extends ShardStoreBaseTest {
 
         // Let the clients run
         Thread.sleep(testLengthSecs * 1000);
+        markEndTimeOfAnyOutstandingRequests();
 
         // Shut the clients down
         shutdownStartedThreads();

--- a/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStorePart2Test.java
+++ b/labs/lab4-shardedstore/tst/dslabs/shardkv/ShardStorePart2Test.java
@@ -193,6 +193,7 @@ public class ShardStorePart2Test extends ShardStoreBaseTest {
         }
 
         Thread.sleep(testLengthSecs * 1000);
+        markEndTimeOfAnyOutstandingRequests();
 
         // Shut everything down
         shutdownStartedThreads();


### PR DESCRIPTION
Previously, the time to stop node threads and the time to check invariants was charged against any outstanding client requests' waiting time. Stopping a node thread requires that the node thread finish executing the current event handler. If the event handler has a performance bug, that will cause `runstate.stop()` to be slow. Similarly, checking invariants can be expensive for long logs.

This commit introduces markEndTimeOfOutstandingRequest, which allows the test to set the ending time of outstanding requests *before* stopping threads and checking invariants. Then, after those (potentially expensive) operations, the tests can assert that the waiting time is acceptable.

Unfortunately this introduces a bit of a sharp corner into the testing framework's internal API: it would be easy to forget to call markEndTimeOfOutstandingRequest before assertMaxWaitTimeLessThan. Perhaps we should add a check for this to help with framework maintenance.

I also added a warning if the framework detects that `runstate.stop()` took longer than one second. That indicates that some event handler in the system took a long time to run. (This warning remains difficult to debug, but at least the new situation is better than the previous one.)