### PR TITLE
Comma separated part numbers for run-tests.py

### DIFF
--- a/handout-files/run-tests.py
+++ b/handout-files/run-tests.py
@@ -199,8 +199,9 @@ def main():
     group = run_modes.add_mutually_exclusive_group()
 
     parser.add_argument('-l', '--lab', help="lab to run tests for")
-    parser.add_argument('-p', '--part', type=int,
-                        help="part number for tests to run")
+
+    parser.add_argument('-p', '--part',
+                        help="part number(s) to run tests for (comma-separated)")
 
     parser.add_argument('-n', '--test-num',
                         help="specific, comma-separated test numbers to run "


### PR DESCRIPTION
Enabled multiple part nums to be run in sequence for run-tests.py. Inspired by the lab 4 part 3 exploit, that doesn't require a working part 2 to get a majority of part 3 points. 

Example terminal commands:
./run-tests.py -l 4 -p 2,3