### PR TITLE
Update handout README jdk instruction

### DIFF
--- a/handout-files/README.md
+++ b/handout-files/README.md
@@ -102,8 +102,8 @@ and/or failures that might lead to a violation of the invariants of the system.
 
 
 ## Getting Started
-The only dependency for these labs is Java 14. Installing `openjdk-14-jdk` on
-most Linux distros should be sufficient.
+The only dependency for these labs is Java 14+. Installing `openjdk-14-jdk` or  
+`openjdk-17-jdk` on most Linux distros should be sufficient.
 
 We recommend using IntelliJ (a configuration directory is included in each
 repo), which also has plugin support for Project Lombok (see below). If you


### PR DESCRIPTION
Students reporting `openjdk-14-jdk` package is getting removed in new releases of distros. As far as I know any jdk 14+ should be compatible to the labs.