### PR TITLE
Add java.time to list of allowed reflective accesses

### DIFF
--- a/.idea/runConfigurations/_template__of_JUnit.xml
+++ b/.idea/runConfigurations/_template__of_JUnit.xml
@@ -4,7 +4,7 @@
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
-    <option name="VM_PARAMETERS" value="-ea --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED" />
+    <option name="VM_PARAMETERS" value="-ea --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED" />
     <option name="PARAMETERS" value="" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/handout-files/.idea/runConfigurations/_template__of_JUnit.xml
+++ b/handout-files/.idea/runConfigurations/_template__of_JUnit.xml
@@ -4,7 +4,7 @@
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
-    <option name="VM_PARAMETERS" value="-ea --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED" />
+    <option name="VM_PARAMETERS" value="-ea --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED" />
     <option name="PARAMETERS" value="" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/handout-files/run-tests.py
+++ b/handout-files/run-tests.py
@@ -26,7 +26,8 @@ BASE_COMMAND = (
     '--add-opens', 'java.base/jdk.internal.reflect=ALL-UNNAMED',
     '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
     '--add-opens', 'java.base/java.util=ALL-UNNAMED',
-    '--add-opens', 'java.base/java.util.concurrent.atomic=ALL-UNNAMED'
+    '--add-opens', 'java.base/java.util.concurrent.atomic=ALL-UNNAMED',
+    '--add-opens', 'java.base/java.time=ALL-UNNAMED',
 )
 
 if platform.system() == 'Windows':


### PR DESCRIPTION
Discovered from a student reporting spurious `--checks` warning about fast cloning and `ClientWorker`:

```
Objects cannot be fast-cloned. Check that they don't contain lambdas or other non-standard fields. This error could also occur due to the use of a data structure the fast-cloning library does not yet support.
- class dslabs.framework.testing.ClientWorker ...
```

Tracked it down by unswallowing the underlying exception to discover:

```
java.lang.reflect.InaccessibleObjectException: Unable to make field private static final long java.time.Instant.MIN_SECOND accessible: module java.base does not "opens java.time" to unnamed module.
```

This pointed to an "illegal" reflective access.

Adding another `--add-opens` fixes it, but we need to add it in three places:
- staff facing IntelliJ run configuration
- student facing IntelliJ run configuration
- (student-facing) `run-tests.py`

I believe this was introduced in the recent refactor of ClientWorker to support better timing information, using `java.time.Instant` as a field, which we had apparently never used in dslabs before (or at least not in a place that the cloning library needed to touch).

There is a separate question of why we are even trying to clone that Instant (either it's a run test, in which case we shouldn't be cloning nodes, or it's a search test, in which case we shouldn't be looking at the clock at all), but I'm ignoring that for now.
