### PR TITLE
Add macOS gsed dependency note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ repository is an auto-built version of the handout.
 The main tools for development are the same as the students' dependencies — Java
 17 and Python 3. You will also need a few utilities such as `wget` to build with
 the provided `Makefile`; MacOS users will need `gtar` and `gcp` provided by the
-`coreutils` Homebrew package.
+`coreutils` Homebrew package, and `gsed` provided by its own Homebrew package.
 
 IntelliJ files are provided and include a code style used by this project. In
 order to provide IntelliJ with all of the necessary libraries, you must run


### PR DESCRIPTION
I didn't have `gsed` installed when I tried running `make`, and the build failed. This dependency isn't included in `coreutils`, so needs to be installed separately.