### PR TITLE
Ignore errors on dir deletion

### DIFF
--- a/handout-files/run-tests.py
+++ b/handout-files/run-tests.py
@@ -51,7 +51,7 @@ def make():
     except subprocess.CalledProcessError as ex:
         print("Could not compile sources.\n")
         print(ex.output.decode("utf-8"))
-        shutil.rmtree('out')
+        shutil.rmtree('out', ignore_errors=True)
         sys.exit(3)
 
 


### PR DESCRIPTION
On running the tests for the first time, it errors out because out folder is not present. 