### PR TITLE
Update time format in logs and test failure messages

### DIFF
--- a/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
+++ b/framework/tst/dslabs/framework/testing/junit/BaseJUnitTest.java
@@ -236,7 +236,7 @@ public abstract class BaseJUnitTest extends DSLabsJUnitTest {
       if (waitTime.toMillis() > allowedMillis) {
         fail(
             String.format(
-                "%s waited too long, %s ms (%s ms allowed), started waiting at %s",
+                "%s waited too long, %s ms (%s ms allowed), started waiting at %4$tF %4$tT.%4$tN",
                 cw.address(),
                 waitTime.toMillis(),
                 allowedMillis,

--- a/framework/tst/dslabs/framework/testing/utils/GlobalSettings.java
+++ b/framework/tst/dslabs/framework/testing/utils/GlobalSettings.java
@@ -78,7 +78,7 @@ public final class GlobalSettings {
 
   static {
     System.setProperty(
-        "java.util.logging.SimpleFormatter.format", "[%4$-7s] [%1$tF %1$tT] [%3$s] %5$s%6$s%n");
+        "java.util.logging.SimpleFormatter.format", "[%4$-7s] [%1$tF %1$tT.%1$tN] [%3$s] %5$s%6$s%n");
 
     // Configure logging
     LogManager logManager = LogManager.getLogManager();

--- a/framework/tst/dslabs/framework/testing/utils/GlobalSettings.java
+++ b/framework/tst/dslabs/framework/testing/utils/GlobalSettings.java
@@ -78,7 +78,8 @@ public final class GlobalSettings {
 
   static {
     System.setProperty(
-        "java.util.logging.SimpleFormatter.format", "[%4$-7s] [%1$tF %1$tT.%1$tN] [%3$s] %5$s%6$s%n");
+        "java.util.logging.SimpleFormatter.format",
+        "[%4$-7s] [%1$tF %1$tT.%1$tN] [%3$s] %5$s%6$s%n");
 
     // Configure logging
     LogManager logManager = LogManager.getLogManager();


### PR DESCRIPTION
The log format is updated with nanosecond-scale resolution. Sample:

```
[FINER  ] [2025-01-15 13:30:54.139487329] [dslabs.framework.Node] MessageReceive(client1 -> pingserver, PingRequest(ping=PingApplication.Ping(value=Hello, World!)))
[FINER  ] [2025-01-15 13:30:54.142355292] [dslabs.framework.Node] TimerReceive(-> client1, PingTimer(ping=PingApplication.Ping(value=Hello, World!)))
[FINER  ] [2025-01-15 13:30:54.150642300] [dslabs.framework.Node] MessageReceive(client1 -> pingserver, PingRequest(ping=PingApplication.Ping(value=Hello, World!)))
[FINER  ] [2025-01-15 13:30:54.151288087] [dslabs.framework.Node] MessageReceive(pingserver -> client1, PongReply(pong=PingApplication.Pong(value=Hello, World!)))
[FINER  ] [2025-01-15 13:30:54.153208765] [dslabs.framework.Node] MessageReceive(pingserver -> client1, PongReply(pong=PingApplication.Pong(value=Hello, World!)))
```

The failure message for maximum waiting time exceeded, while already in nanosecond-scale resolution, has been updated to keep consistency. Sample:

```
java.lang.AssertionError: client3 waited too long, 8576 ms (3000 ms allowed), started waiting at 2025-01-15 13:27:20.554216249
```

The previously second-scale resolution in log message is not enough for identifying livelock-related bugs, because the timeouts are in millisecond scale.

Besides, I am planning to make a message diagram style log visualizer for run tests, which can benefit from finer-grained time in the logs.

(The original idea is to update with microsecond-scale resolution, but apparently there's no format conversion for that according to [Formatter](https://docs.oracle.com/en/java/javase/17/docs/api//java.base/java/util/Formatter.html).)